### PR TITLE
masync: add expanded future notifier types

### DIFF
--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -28,7 +28,7 @@ struct async_print_output {
 FUTURE(async_print_fut, struct async_print_data, struct async_print_output);
 
 static enum future_state
-async_print_impl(struct future_context *ctx, struct future_waker waker)
+async_print_impl(struct future_context *ctx, struct future_notifier *notifier)
 {
 	struct async_print_data *data = future_context_get_data(ctx);
 	printf("async print: %p\n", data->value);
@@ -96,7 +96,7 @@ main(int argc, char *argv[])
 	char *buf_b = strdup("otherbuf");
 	struct runtime *r = runtime_new();
 
-	struct vdm *pthread_mover = vdm_new(vdm_descriptor_pthreads());
+	struct vdm *pthread_mover = vdm_new(vdm_descriptor_pthreads_polled());
 	struct vdm_memcpy_future a_to_b =
 		vdm_memcpy(pthread_mover, buf_b, buf_a, testbuf_size);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,8 +14,8 @@ add_check_whitespace(src
 
 set(SOURCES
     future.c
-    vdm.c
     runtime.c
+    vdm.c
 )
 
 add_library(miniasync SHARED ${SOURCES})

--- a/src/include/libminiasync/vdm.h
+++ b/src/include/libminiasync/vdm.h
@@ -13,10 +13,10 @@
  * Intel DSA (Data Streaming Accelerator), plain threads,
  * or synchronous operations in the current working thread.
  *
- * Data movers need to implement the runner interface, and applications can use
- * such implementations to create a concrete mover. Software can then use movers
- * to create more complex generic concurrent futures that use asynchronous
- * memory operations.
+ * Data movers need to implement the descriptor interface, and applications can
+ * use such implementations to create a concrete mover. Software can then use
+ * movers to create more complex generic concurrent futures that use
+ * asynchronous memory operations.
  */
 
 #ifndef VDM_H
@@ -30,7 +30,7 @@ typedef void (*vdm_cb_fn)(struct future_context *context);
 typedef void (*vdm_data_fn)(void **vdm_data);
 
 struct vdm_memcpy_data {
-	struct future_waker waker;
+	struct future_notifier notifier;
 	int complete;
 	struct vdm *vdm;
 	void *dest;
@@ -49,7 +49,8 @@ FUTURE(vdm_memcpy_future,
 struct vdm_memcpy_future vdm_memcpy(struct vdm *vdm,
 	void *dest, void *src, size_t n);
 
-typedef void (*async_memcpy_fn)(void *runner, struct future_context *context);
+typedef void (*async_memcpy_fn)(void *descriptor,
+	struct future_notifier *notifier, struct future_context *context);
 
 struct vdm_descriptor {
 	vdm_data_fn vdm_data_init;
@@ -59,7 +60,7 @@ struct vdm_descriptor {
 
 struct vdm_descriptor *vdm_descriptor_synchronous(void);
 struct vdm_descriptor *vdm_descriptor_pthreads(void);
-
+struct vdm_descriptor *vdm_descriptor_pthreads_polled(void);
 struct vdm *vdm_new(struct vdm_descriptor *descriptor);
 void vdm_delete(struct vdm *vdm);
 void *vdm_get_data(struct vdm *vdm);

--- a/src/vdm.c
+++ b/src/vdm.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2021, Intel Corporation */
+/* Copyright 2021, Intel Corporation */
 
 #include <pthread.h>
 #include <stdlib.h>
@@ -48,17 +48,27 @@ vdm_memcpy_cb(struct future_context *context)
 {
 	struct vdm_memcpy_data *data = future_context_get_data(context);
 	util_atomic_store64(&data->complete, 1);
-	FUTURE_WAKER_WAKE(&data->waker);
+	if (data->notifier.notifier_used == FUTURE_NOTIFIER_WAKER)
+		FUTURE_WAKER_WAKE(&data->notifier.waker);
 }
 
 static enum future_state
-vdm_memcpy_impl(struct future_context *context, struct future_waker waker)
+vdm_memcpy_impl(struct future_context *context, struct future_notifier *n)
 {
 	struct vdm_memcpy_data *data = future_context_get_data(context);
 	if (context->state == FUTURE_STATE_IDLE) {
-		data->waker = waker;
+		if (n) {
+			data->notifier = *n;
+		} else {
+			data->notifier.notifier_used = FUTURE_NOTIFIER_NONE;
+		}
+
 		data->vdm_cb = vdm_memcpy_cb;
-		data->vdm->descriptor->memcpy(data->vdm->descriptor, context);
+		data->vdm->descriptor->memcpy(data->vdm->descriptor,
+			&data->notifier, context);
+		if (n) {
+			*n = data->notifier;
+		}
 	}
 	int complete;
 	util_atomic_load64(&data->complete, &complete);
@@ -81,12 +91,21 @@ vdm_memcpy(struct vdm *vdm, void *dest, void *src, size_t n)
 }
 
 static void
-memcpy_sync(void *runner, struct future_context *context)
+memcpy_impl(void *descriptor, struct future_context *context)
 {
 	struct vdm_memcpy_data *data = future_context_get_data(context);
 	struct vdm_memcpy_output *output = future_context_get_output(context);
 	output->dest = memcpy(data->dest, data->src, data->n);
 	data->vdm_cb(context);
+}
+
+static void
+memcpy_sync(void *descriptor, struct future_notifier *notifier,
+	struct future_context *context)
+{
+	notifier->notifier_used = FUTURE_NOTIFIER_NONE;
+
+	memcpy_impl(descriptor, context);
 }
 
 static struct vdm_descriptor synchronous_descriptor = {
@@ -104,14 +123,30 @@ vdm_descriptor_synchronous(void)
 static void *
 async_memcpy_pthread(void *arg)
 {
-	memcpy_sync(NULL, arg);
+	memcpy_impl(NULL, arg);
 
 	return NULL;
 }
 
 static void
-memcpy_pthreads(void *runner, struct future_context *context)
+memcpy_pthreads(void *descriptor, struct future_notifier *notifier,
+	struct future_context *context)
 {
+	notifier->notifier_used = FUTURE_NOTIFIER_WAKER;
+
+	pthread_t thread;
+	pthread_create(&thread, NULL, async_memcpy_pthread, context);
+}
+
+static void
+memcpy_pthreads_polled(void *descriptor, struct future_notifier *notifier,
+	struct future_context *context)
+{
+	struct vdm_memcpy_data *data = future_context_get_data(context);
+
+	notifier->notifier_used = FUTURE_NOTIFIER_POLLER;
+	notifier->poller.ptr_to_monitor = (uint64_t *)&data->complete;
+
 	pthread_t thread;
 	pthread_create(&thread, NULL, async_memcpy_pthread, context);
 }
@@ -126,4 +161,14 @@ struct vdm_descriptor *
 vdm_descriptor_pthreads(void)
 {
 	return &pthreads_descriptor;
+}
+
+static struct vdm_descriptor pthreads_polled_descriptor = {
+	.memcpy = memcpy_pthreads_polled,
+};
+
+struct vdm_descriptor *
+vdm_descriptor_pthreads_polled(void)
+{
+	return &pthreads_polled_descriptor;
 }


### PR DESCRIPTION
This enables futures and runtimes to support a wider
variety of different notification mechanisms for indicating
that a future is ready to be polled again.
This PR implements pollers, which can allow runtimes to use
optimized umwait/umonitor instructions when possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/15)
<!-- Reviewable:end -->
