### PR TITLE
masync: fix uninitialized variable in vdm

### DIFF
--- a/src/vdm.c
+++ b/src/vdm.c
@@ -56,6 +56,7 @@ vdm_memcpy(struct vdm *vdm, void *dest, void *src, size_t n)
 	future.data.src = src;
 	future.data.n = n;
 	future.data.complete = 0;
+	future.output = (struct vdm_memcpy_output){ NULL };
 	FUTURE_INIT(&future, vdm_memcpy_impl);
 
 	return future;


### PR DESCRIPTION
Found by coverity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/21)
<!-- Reviewable:end -->
