### PR TITLE
masync: move vdm_data and add init/fini funcs

### DIFF
--- a/src/include/libminiasync/vdm.h
+++ b/src/include/libminiasync/vdm.h
@@ -27,6 +27,7 @@
 struct vdm;
 
 typedef void (*vdm_cb_fn)(struct future_context *context);
+typedef void (*vdm_data_fn)(void **vdm_data);
 
 struct vdm_memcpy_data {
 	struct future_waker waker;
@@ -51,7 +52,8 @@ struct vdm_memcpy_future vdm_memcpy(struct vdm *vdm,
 typedef void (*async_memcpy_fn)(void *runner, struct future_context *context);
 
 struct vdm_descriptor {
-	void *vdm_data;
+	vdm_data_fn vdm_data_init;
+	vdm_data_fn vdm_data_fini;
 	async_memcpy_fn memcpy;
 };
 
@@ -59,7 +61,7 @@ struct vdm_descriptor *vdm_descriptor_synchronous(void);
 struct vdm_descriptor *vdm_descriptor_pthreads(void);
 
 struct vdm *vdm_new(struct vdm_descriptor *descriptor);
-
 void vdm_delete(struct vdm *vdm);
+void *vdm_get_data(struct vdm *vdm);
 
 #endif


### PR DESCRIPTION
vdm_data was moved from vdm_descriptor to vdm.
vdm_descriptor stores pointers to the vdm_data init/fini functions
instead. This allows vdm implementations to manage the data that
those implementations might need for the lifetime of a mover
instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/30)
<!-- Reviewable:end -->
