### PR TITLE
masync: fix private headers inside public vdm.h header

### DIFF
--- a/src/include/libminiasync/vdm.h
+++ b/src/include/libminiasync/vdm.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /*
  * vdm.h - public definitions for an abstract virtual data mover (VDM) type.
@@ -23,8 +23,6 @@
 #define VDM_H 1
 
 #include "future.h"
-#include "core/ringbuf.h"
-#include "core/os_thread.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/include/libminiasync/vdm_threads.h
+++ b/src/include/libminiasync/vdm_threads.h
@@ -4,9 +4,6 @@
 #ifndef VDM_THREADS_H
 #define VDM_THREADS_H
 
-#include "future.h"
-#include "core/os_thread.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Fix for wrong includes in vdm.h and vdm_threads.h header files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/44)
<!-- Reviewable:end -->
