### PR TITLE
common: fix minor warnings on Windows

### DIFF
--- a/examples/basic/basic.c
+++ b/examples/basic/basic.c
@@ -32,6 +32,10 @@ FUTURE(async_print_fut, struct async_print_data, struct async_print_output);
 static enum future_state
 async_print_impl(struct future_context *ctx, struct future_notifier *notifier)
 {
+	if (notifier != NULL) {
+		notifier->notifier_used = FUTURE_NOTIFIER_NONE;
+	}
+
 	struct async_print_data *data = future_context_get_data(ctx);
 	printf("async print: %p\n", data->value);
 
@@ -102,12 +106,17 @@ async_memcpy_print(struct vdm *vdm, void *dest, void *src, size_t n)
 
 /* Main - creates instances and executes the futures */
 int
-main(int argc, char *argv[])
+main(void)
 {
 	/* Set up the data, create runtime and desired mover */
 	size_t testbuf_size = strlen("testbuf");
-	char *buf_a = strdup("testbuf");
-	char *buf_b = strdup("otherbuf");
+	size_t otherbuf_size = strlen("otherbuf");
+
+	char *buf_a = malloc(testbuf_size + 1);
+	char *buf_b = malloc(otherbuf_size + 1);
+
+	memcpy(buf_a, "testbuf", testbuf_size + 1);
+	memcpy(buf_b, "otherbuf", otherbuf_size + 1);
 
 	struct runtime *r = runtime_new();
 

--- a/src/core/os_thread_windows.c
+++ b/src/core/os_thread_windows.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2021, Intel Corporation */
+/* Copyright 2015-2022, Intel Corporation */
 /*
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
@@ -493,6 +493,9 @@ int
 os_thread_create(os_thread_t *thread, const os_thread_attr_t *attr,
 	void *(*start_routine)(void *), void *arg)
 {
+	/* to avoid unused formal parameter warning */
+	SUPPRESS_UNUSED(attr);
+
 	COMPILE_ERROR_ON(sizeof(os_thread_t) < sizeof(internal_os_thread_t));
 	internal_os_thread_t *thread_info = (internal_os_thread_t *)thread;
 
@@ -590,6 +593,9 @@ int
 os_thread_setaffinity_np(os_thread_t *thread, size_t set_size,
 	const os_cpu_set_t *set)
 {
+	/* to avoid unused formal parameter warning */
+	SUPPRESS_UNUSED(set_size);
+
 	internal_os_cpu_set_t *internal_set = (internal_os_cpu_set_t *)set;
 	internal_os_thread_t *internal_thread = (internal_os_thread_t *)thread;
 

--- a/src/core/os_windows.c
+++ b/src/core/os_windows.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2017-2021, Intel Corporation */
+/* Copyright 2017-2022, Intel Corporation */
 /*
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  * Redistribution and use in source and binary forms, with or without
@@ -34,10 +34,14 @@
 /*
  * os_windows.c -- windows abstraction layer
  */
+
+#define _CRT_RAND_S
+
 #include <windows.h>
 #include <io.h>
 #include <sys/locking.h>
 #include <errno.h>
+#include <stdlib.h>
 
 #include "alloc.h"
 #include "util.h"
@@ -114,6 +118,9 @@ os_fsync(int fd)
 int
 os_fsync_dir(const char *dir_name)
 {
+	/* to avoid unused formal parameter warning */
+	SUPPRESS_UNUSED(dir_name);
+
 	/* XXX not used and not implemented */
 	ASSERT(0);
 	return -1;

--- a/src/future.c
+++ b/src/future.c
@@ -2,6 +2,7 @@
 /* Copyright 2019-2022, Intel Corporation */
 
 #include "libminiasync/future.h"
+#include "core/util.h"
 
 void *
 future_context_get_data(struct future_context *context)
@@ -69,7 +70,8 @@ async_chain_impl(struct future_context *ctx, struct future_notifier *notifier)
 static void
 future_wake_noop(void *data)
 {
-
+	/* to avoid unused formal parameter warning */
+	SUPPRESS_UNUSED(data);
 }
 
 struct future_notifier

--- a/src/windows/include/platform.h
+++ b/src/windows/include/platform.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2015-2021, Intel Corporation */
+/* Copyright 2015-2022, Intel Corporation */
 /*
  * Copyright (c) 2016, Microsoft Corporation. All rights reserved.
  *
@@ -156,7 +156,7 @@ sigemptyset(sigset_t *set)
 __inline int
 sigfillset(sigset_t *set)
 {
-	*set = ~0;
+	*set = (sigset_t)~0;
 	return 0;
 }
 

--- a/tests/dml_vdm/dml_vdm.c
+++ b/tests/dml_vdm/dml_vdm.c
@@ -55,7 +55,7 @@ test_dml_hw_path_flag_memcpy()
 }
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	int ret = test_dml_basic_memcpy();
 	if (ret)

--- a/tests/dummy/dummy.c
+++ b/tests/dummy/dummy.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(int argc, char *argv[]) {
+int main(void) {
 		printf("what's happening with test output?\n");
 		float *ptr = (float *)malloc(100 * sizeof(float));
 		/* comment free to test memcheck */

--- a/tests/dummy_negative/dummy_negative.c
+++ b/tests/dummy_negative/dummy_negative.c
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 #include <stdio.h>
 #include <stdlib.h>
 
-int main(int argc, char *argv[]) {
+int main(void) {
 		return 1;
 }

--- a/tests/memcpy_threads/memcpy_threads.c
+++ b/tests/memcpy_threads/memcpy_threads.c
@@ -86,7 +86,7 @@ test_threads_memcpy_multiple(unsigned memcpy_count,
 			ret = 1;
 			goto cleanup;
 		}
-		printf("Memcpy nr. %u from [%p] to [%p] n=%lu "
+		printf("Memcpy nr. %u from [%p] to [%p] n=%zu "
 			"content=sequence is correct\n", i, sources[i],
 			destinations[i], sizes[i]);
 	}
@@ -109,7 +109,7 @@ cleanup:
 }
 
 int
-main(int argc, char *argv[])
+main(void)
 {
 	return
 		test_threads_memcpy_multiple(100, 10, 10,


### PR DESCRIPTION
Includes fixes for:
-  'strdup': The POSIX name for this item is deprecated warning
-  various unreferenced formal parameter warnings
-  conversion from 'int' to 'sigset_t' warning
-  'rand_s' undefined warning
-  'printf' : format string '%lu' requires an argument of type 'unsigned long', but variadic argument 4 has type 'size_t' warning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/46)
<!-- Reviewable:end -->
