### PR TITLE
common: fix padding warnings on Windows

### DIFF
--- a/src/core/os_thread_windows.c
+++ b/src/core/os_thread_windows.c
@@ -50,19 +50,22 @@
 #include "out.h"
 
 typedef struct {
-	unsigned attr;
 	CRITICAL_SECTION lock;
+	unsigned attr;
+	uint32_t padding;
 } internal_os_mutex_t;
 
 typedef struct {
+	SRWLOCK lock;
 	unsigned attr;
 	char is_write;
-	SRWLOCK lock;
+	char padding[3];
 } internal_os_rwlock_t;
 
 typedef struct {
-	unsigned attr;
 	CONDITION_VARIABLE cond;
+	unsigned attr;
+	uint32_t padding;
 } internal_os_cond_t;
 
 typedef long long internal_os_once_t;

--- a/src/core/ringbuf.c
+++ b/src/core/ringbuf.c
@@ -41,8 +41,8 @@ struct ringbuf {
 	CACHELINE_PADDING(os_semaphore_t, nfree);
 	CACHELINE_PADDING(os_semaphore_t, nused);
 
-	unsigned len;
 	uint64_t len_mask;
+	unsigned len;
 	int running;
 
 	void *data[];

--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -78,9 +78,10 @@ enum future_state {
 };
 
 struct future_context {
-	enum future_state state;
 	size_t data_size;
 	size_t output_size;
+	enum future_state state;
+	uint32_t padding;
 };
 
 typedef void (*future_waker_wake_fn)(void *data);
@@ -101,9 +102,10 @@ enum future_notifier_type {
 };
 
 struct future_notifier {
-	enum future_notifier_type notifier_used;
 	struct future_waker waker;
 	struct future_poller poller;
+	enum future_notifier_type notifier_used;
+	uint32_t padding;
 };
 
 void *future_context_get_data(struct future_context *context);

--- a/src/windows/include/platform.h
+++ b/src/windows/include/platform.h
@@ -142,8 +142,9 @@ struct sigaction {
 	void (*sa_handler) (int signum);
 	/* void (*sa_sigaction)(int, siginfo_t *, void *); */
 	sigset_t sa_mask;
-	int sa_flags;
 	void (*sa_restorer) (void);
+	int sa_flags;
+	uint32_t padding;
 };
 
 __inline int


### PR DESCRIPTION
Includes fixes for all the `padding added after data member` warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/47)
<!-- Reviewable:end -->
