### PR TITLE
common: fix type mismatch warnings on Windows

### DIFF
--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -40,7 +40,7 @@ cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 static inline void
 cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 {
-	__cpuidex(cpuinfo, func, subfunc);
+	__cpuidex((int *)cpuinfo, (int)func, (int)subfunc);
 }
 
 #else

--- a/src/core/os_thread_windows.c
+++ b/src/core/os_thread_windows.c
@@ -565,9 +565,9 @@ void
 os_cpu_set(size_t cpu, os_cpu_set_t *set)
 {
 	internal_os_cpu_set_t *internal_set = (internal_os_cpu_set_t *)set;
-	int sum = 0;
-	int group_max = GetActiveProcessorGroupCount();
-	int group = 0;
+	size_t sum = 0;
+	WORD group_max = GetActiveProcessorGroupCount();
+	WORD group = 0;
 	while (group < group_max) {
 		sum += GetActiveProcessorCount(group);
 		if (sum > cpu) {

--- a/src/core/out.c
+++ b/src/core/out.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2014-2021, Intel Corporation */
+/* Copyright 2014-2022, Intel Corporation */
 
 /*
  * out.c -- support for logging, tracing, and assertion output
@@ -238,16 +238,6 @@ out_init(const char *log_prefix, const char *log_level_var,
 		"compiled with support for Valgrind drd";
 	LOG(1, "%s", drd_msg);
 #endif /* VG_DRD_ENABLED */
-#if SDS_ENABLED
-	static __attribute__((used)) const char *shutdown_state_msg =
-		"compiled with support for shutdown state";
-	LOG(1, "%s", shutdown_state_msg);
-#endif
-#if NDCTL_ENABLED
-	static __attribute__((used)) const char *ndctl_ge_63_msg =
-		"compiled with libndctl 63+";
-	LOG(1, "%s", ndctl_ge_63_msg);
-#endif
 
 	Last_errormsg_key_alloc();
 }

--- a/src/core/util_windows.c
+++ b/src/core/util_windows.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2015-2021, Intel Corporation */
+/* Copyright 2015-2022, Intel Corporation */
 
 /*
  * util_windows.c -- misc utilities with OS-specific implementation
@@ -130,7 +130,7 @@ util_tmpfile(const char *dir, const char *templ, int flags)
 	}
 
 	int ret = _snprintf(fullname, len, "%s%s", dir, templ);
-	if (ret < 0 || ret >= len) {
+	if (ret < 0 || (size_t)ret >= len) {
 		ERR("snprintf: %d", ret);
 		goto err;
 	}
@@ -273,7 +273,7 @@ util_toUTF16_buff(const char *in, wchar_t *out, size_t out_size)
 
 	int size = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, in,
 		-1, NULL, 0);
-	if (size == 0 || out_size < size)
+	if (size == 0 || out_size < (size_t)size)
 		goto err;
 
 	if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, in, -1,
@@ -298,7 +298,7 @@ util_toUTF8_buff(const wchar_t *in, char *out, size_t out_size)
 
 	int size = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, in, -1,
 		NULL, 0, NULL, NULL);
-	if (size == 0 || out_size < size)
+	if (size == 0 || out_size < (size_t)size)
 		goto err;
 
 	if (WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, in, -1,

--- a/src/core/valgrind_internal.h
+++ b/src/core/valgrind_internal.h
@@ -8,13 +8,12 @@
 #ifndef MINIASYNC_VALGRIND_INTERNAL_H
 #define MINIASYNC_VALGRIND_INTERNAL_H 1
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-function"
-
 #if !defined(_WIN32) && !defined(__FreeBSD__) && !defined(__riscv)
 #ifndef VALGRIND_ENABLED
 #define VALGRIND_ENABLED 1
 #endif
+#else
+#define VALGRIND_ENABLED 0
 #endif
 
 #if VALGRIND_ENABLED
@@ -22,6 +21,11 @@
 #define VG_HELGRIND_ENABLED 1
 #define VG_MEMCHECK_ENABLED 1
 #define VG_DRD_ENABLED 1
+#else
+#define VG_PMEMCHECK_ENABLED 0
+#define VG_HELGRIND_ENABLED 0
+#define VG_MEMCHECK_ENABLED 0
+#define VG_DRD_ENABLED 0
 #endif
 
 #if VG_PMEMCHECK_ENABLED || VG_HELGRIND_ENABLED || VG_MEMCHECK_ENABLED || \
@@ -434,7 +438,5 @@ extern unsigned _On_memcheck;
 	do { (void) (addr); (void) (len); } while (0)
 
 #endif
-
-#pragma GCC diagnostic pop
 
 #endif

--- a/src/windows/include/platform.h
+++ b/src/windows/include/platform.h
@@ -80,7 +80,9 @@ extern "C" {
 #define __thread __declspec(thread)
 #define __func__ __FUNCTION__
 #ifdef _DEBUG
+#ifndef DEBUG
 #define DEBUG
+#endif
 #endif
 
 /*


### PR DESCRIPTION
Includes fixes for:
-  conversion from 'int' to 'WORD', possible loss of data warning
-  signed/unsigned mismatch warnings
-  'int *' differs in indirection to slightly different base types from 'unsigned int *' warning
- 'DEBUG' macro redefinition warning
- undefined macros in `valgrind_internal.h` file warnings
- undefined macros in `out.c` file warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/49)
<!-- Reviewable:end -->
