### PR TITLE
masync: simplify membuf memory reclamation

### DIFF
--- a/extras/dml/data_mover_dml.c
+++ b/extras/dml/data_mover_dml.c
@@ -149,6 +149,8 @@ data_mover_dml_operation_delete(void *op, struct vdm_operation_output *output)
 	}
 
 	data_mover_dml_memcpy_job_delete(&job);
+
+	membuf_free(op);
 }
 
 /*
@@ -182,32 +184,6 @@ data_mover_dml_operation_start(void *op, struct future_notifier *n)
 }
 
 /*
- * data_mover_dml_membuf_check -- returns the status of the dml job
- */
-enum membuf_check_result
-data_mover_dml_membuf_check(void *ptr, void *data)
-{
-	switch (data_mover_dml_operation_check(ptr)) {
-		case FUTURE_STATE_COMPLETE:
-			return MEMBUF_PTR_CAN_REUSE;
-		case FUTURE_STATE_RUNNING:
-			return MEMBUF_PTR_CAN_WAIT;
-		case FUTURE_STATE_IDLE:
-			return MEMBUF_PTR_IN_USE;
-	}
-	ASSERT(0);
-}
-
-/*
- * data_mover_dml_membuf_size -- returns the size of a dml job
- */
-static size_t
-data_mover_dml_membuf_size(void *ptr, void *data)
-{
-	return sizeof(dml_job_t);
-}
-
-/*
  * data_mover_dml_vdm -- dml asynchronous memcpy
  */
 static struct vdm data_mover_dml_vdm = {
@@ -227,8 +203,7 @@ data_mover_dml_new(void)
 	if (vdm_dml == NULL)
 		return NULL;
 
-	vdm_dml->membuf = membuf_new(data_mover_dml_membuf_check,
-		data_mover_dml_membuf_size, NULL, vdm_dml);
+	vdm_dml->membuf = membuf_new(vdm_dml);
 	vdm_dml->base = data_mover_dml_vdm;
 
 	return vdm_dml;

--- a/src/core/membuf.c
+++ b/src/core/membuf.c
@@ -32,10 +32,13 @@ struct membuf {
 	struct threadbuf *tbuf_unused_first; /* list of threadbufs for reuse */
 
 	os_tls_key_t bufkey; /* TLS key for threadbuf */
-	membuf_ptr_check check_func; /* object state check function */
-	membuf_ptr_size size_func; /* object size function */
-	void *func_data; /* user-provided function argument */
 	void *user_data; /* user-provided buffer data */
+};
+
+struct membuf_entry {
+	int32_t allocated; /* 1 - allocated, 0 - unused */
+	uint32_t size; /* size of the entry */
+	char data[]; /* user data */
 };
 
 /*
@@ -64,17 +67,13 @@ membuf_key_destructor(void *data)
  * membuf_new -- allocates and initializes a new membuf instance
  */
 struct membuf *
-membuf_new(membuf_ptr_check check_func, membuf_ptr_size size_func,
-	void *func_data, void *user_data)
+membuf_new(void *user_data)
 {
 	struct membuf *membuf = malloc(sizeof(struct membuf));
 	if (membuf == NULL)
 		return NULL;
 
 	membuf->user_data = user_data;
-	membuf->check_func = check_func;
-	membuf->size_func = size_func;
-	membuf->func_data = func_data;
 	membuf->tbuf_first = NULL;
 	membuf->tbuf_unused_first = NULL;
 	os_mutex_init(&membuf->lists_lock);
@@ -98,6 +97,34 @@ membuf_delete(struct membuf *membuf)
 	}
 	os_mutex_destroy(&membuf->lists_lock);
 	free(membuf);
+}
+
+/*
+ * membuf_entry_get_size -- returns the size of an entry
+ */
+static size_t
+membuf_entry_get_size(void *real_ptr)
+{
+	struct membuf_entry *entry = real_ptr;
+
+	uint32_t size;
+	util_atomic_load_explicit32(&entry->size, &size, memory_order_acquire);
+
+	return size;
+}
+
+/*
+ * membuf_entry_is_allocated -- checks whether the entry is allocated
+ */
+static int
+membuf_entry_is_allocated(void *real_ptr)
+{
+	struct membuf_entry *entry = real_ptr;
+	int32_t allocated;
+	util_atomic_load_explicit32(&entry->allocated,
+		&allocated, memory_order_acquire);
+
+	return allocated;
 }
 
 /*
@@ -147,7 +174,7 @@ membuf_get_threadbuf(struct membuf *membuf)
 /*
  * membuf_threadbuf_prune -- reclaims available buffer space
  */
-static int
+static void
 membuf_threadbuf_prune(struct membuf *membuf,
 	struct threadbuf *tbuf)
 {
@@ -165,20 +192,11 @@ membuf_threadbuf_prune(struct membuf *membuf,
 		/* check the next object after the available memory */
 		size_t next_loc = (tbuf->offset + tbuf->available) % tbuf->size;
 		void *next = &tbuf->buf[next_loc];
-		switch (membuf->check_func(next, membuf->func_data)) {
-			case MEMBUF_PTR_CAN_REUSE: {
-				size_t s = membuf->size_func(next,
-					membuf->func_data);
-				tbuf->available += s;
-			} break;
-			case MEMBUF_PTR_CAN_WAIT:
-				return 0;
-			case MEMBUF_PTR_IN_USE:
-				return -1;
-		}
-	}
+		if (membuf_entry_is_allocated(next))
+			return;
 
-	return 0;
+		tbuf->available += membuf_entry_get_size(next);
+	}
 }
 
 /*
@@ -191,32 +209,50 @@ membuf_alloc(struct membuf *membuf, size_t size)
 	if (tbuf == NULL)
 		return NULL;
 
-	if (size > tbuf->size)
+	size_t real_size = size + sizeof(struct membuf_entry);
+
+	if (real_size > tbuf->size)
 		return NULL;
 
-	if (tbuf->offset + size > tbuf->size) {
+	if (tbuf->offset + real_size > tbuf->size) {
 		tbuf->leftovers = tbuf->available;
 		tbuf->offset = 0;
 		tbuf->available = 0;
 	}
 
 	/* wait until enough memory becomes available */
-	while (size > tbuf->available) {
-		if (membuf_threadbuf_prune(membuf, tbuf) < 0) {
-			/*
-			 * Fail if not enough space was reclaimed and no
-			 * memory is available for further reclamation.
-			 */
-			if (size > tbuf->available)
-				return NULL;
-		}
+	if (real_size > tbuf->available) {
+		membuf_threadbuf_prune(membuf, tbuf);
+		/*
+		 * Fail if not enough space was reclaimed and no
+		 * memory is available for further reclamation.
+		 */
+		if (real_size > tbuf->available)
+			return NULL;
 	}
 
 	size_t pos = tbuf->offset;
-	tbuf->offset += size;
-	tbuf->available -= size;
+	tbuf->offset += real_size;
+	tbuf->available -= real_size;
 
-	return &tbuf->buf[pos];
+	struct membuf_entry *entry = (struct membuf_entry *)&tbuf->buf[pos];
+	entry->size = real_size;
+	entry->allocated = 1;
+
+	return &entry->data;
+}
+
+/*
+ * membuf_free -- deallocates an entry
+ */
+void
+membuf_free(void *ptr)
+{
+	struct membuf_entry *entry = (struct membuf_entry *)
+		((uintptr_t)ptr - sizeof(struct membuf_entry));
+
+	util_atomic_store_explicit64(&entry->allocated, 0,
+		memory_order_release);
 }
 
 /*

--- a/src/core/membuf.h
+++ b/src/core/membuf.h
@@ -4,8 +4,8 @@
 /*
  * membuf.h -- definitions for "membuf" module.
  *
- * Membuf is a circular object buffer with automatic reclamation. Each instance
- * uses an internal per-thread buffer to avoid heavyweight synchronization.
+ * Membuf is a circular object buffer. Each instance uses an internal
+ * per-thread buffer to avoid heavyweight synchronization.
  *
  * Allocation is linear and very cheap. The expectation is that objects within
  * the buffer will be reclaimable long before the linear allocator might need
@@ -19,34 +19,11 @@
 
 struct membuf;
 
-enum membuf_check_result {
-	/*
-	 * Cannot reclaim memory object, alloc will fail. This should be used
-	 * when object is owned by the current working thread.
-	 */
-	MEMBUF_PTR_IN_USE,
-
-	/*
-	 * Cannot reclaim memory object, alloc will busy-poll. This should be
-	 * used when object is being processed in the background.
-	 */
-	MEMBUF_PTR_CAN_WAIT,
-
-	/*
-	 * Can reclaim memory object, alloc will reuse memory.
-	 */
-	MEMBUF_PTR_CAN_REUSE,
-};
-
-typedef enum membuf_check_result (*membuf_ptr_check)(void *ptr, void *data);
-typedef size_t (*membuf_ptr_size)(void *ptr, void *data);
-
-struct membuf *membuf_new(membuf_ptr_check check_func,
-	membuf_ptr_size size_func,
-	void *func_data, void *user_data);
+struct membuf *membuf_new(void *user_data);
 void membuf_delete(struct membuf *membuf);
 
 void *membuf_alloc(struct membuf *membuf, size_t size);
+void membuf_free(void *ptr);
 
 void *membuf_ptr_user_data(void *ptr);
 

--- a/src/data_mover_sync.c
+++ b/src/data_mover_sync.c
@@ -38,25 +38,6 @@ sync_operation_check(void *op)
 }
 
 /*
- * sync_membuf_check -- checks the status of a sync job
- */
-static enum membuf_check_result
-sync_membuf_check(void *ptr, void *data)
-{
-	return sync_operation_check(ptr) == FUTURE_STATE_COMPLETE ?
-		MEMBUF_PTR_CAN_REUSE : MEMBUF_PTR_IN_USE;
-}
-
-/*
- * sync_membuf_size -- returns the size of a sync operation
- */
-static size_t
-sync_membuf_size(void *ptr, void *data)
-{
-	return sizeof(struct data_mover_sync_op);
-}
-
-/*
  * sync_operation_new -- creates a new sync operation
  */
 static void *
@@ -90,6 +71,8 @@ sync_operation_delete(void *op, struct vdm_operation_output *output)
 		default:
 			ASSERT(0);
 	}
+
+	membuf_free(op);
 }
 
 /*
@@ -129,8 +112,7 @@ data_mover_sync_new(void)
 		return NULL;
 
 	dms->base = data_mover_sync_vdm;
-	dms->membuf = membuf_new(sync_membuf_check, sync_membuf_size,
-		NULL, dms);
+	dms->membuf = membuf_new(dms);
 	if (dms->membuf == NULL)
 		goto membuf_failed;
 

--- a/src/data_mover_threads.c
+++ b/src/data_mover_threads.c
@@ -134,34 +134,6 @@ data_mover_threads_operation_check(void *op)
 }
 
 /*
- * data_mover_threads_membuf_check -- checks the status of a threads job
- */
-static enum membuf_check_result
-data_mover_threads_membuf_check(void *ptr, void *data)
-{
-	switch (data_mover_threads_operation_check(ptr)) {
-		case FUTURE_STATE_COMPLETE:
-			return MEMBUF_PTR_CAN_REUSE;
-		case FUTURE_STATE_RUNNING:
-			return MEMBUF_PTR_CAN_WAIT;
-		case FUTURE_STATE_IDLE:
-			return MEMBUF_PTR_IN_USE;
-	}
-
-	ASSERT(0);
-	return MEMBUF_PTR_IN_USE;
-}
-
-/*
- * data_mover_threads_membuf_size -- returns the size of a threads job size
- */
-static size_t
-data_mover_threads_membuf_size(void *ptr, void *data)
-{
-	return sizeof(struct data_mover_threads_op);
-}
-
-/*
  * data_mover_threads_operation_new -- create a new thread operation that uses
  * wakers
  */
@@ -204,6 +176,8 @@ data_mover_threads_operation_delete(void *op,
 		default:
 			ASSERT(0);
 	}
+
+	membuf_free(op);
 }
 
 /*
@@ -262,8 +236,7 @@ data_mover_threads_new(size_t nthreads, size_t ringbuf_size,
 	if (dmt_threads->buf == NULL)
 		goto ringbuf_failed;
 
-	dmt_threads->membuf = membuf_new(data_mover_threads_membuf_check,
-		data_mover_threads_membuf_size, NULL, dmt_threads);
+	dmt_threads->membuf = membuf_new(dmt_threads);
 	if (dmt_threads->membuf == NULL)
 		goto membuf_failed;
 

--- a/tests/membuf/membuf_simple.c
+++ b/tests/membuf/membuf_simple.c
@@ -6,55 +6,19 @@
 #include "core/membuf.h"
 #include "test_helpers.h"
 
-#define TEST_FUNC_DATA (void *)(0xDEADBEEF)
-#define TEST_USER_DATA (void *)(0xC0FFEA)
+#define TEST_USER_DATA (void *)(0xC0FFEE)
 
 #define TEST_ENTRY_PADDING (1 << 11)
 #define MAX_TEST_ENTRIES (100000)
 
 struct test_entry {
-	enum membuf_check_result check;
-	size_t size;
 	char padding[TEST_ENTRY_PADDING];
 };
-
-static enum membuf_check_result
-test_check(void *ptr, void *data)
-{
-	UT_ASSERTeq(data, TEST_FUNC_DATA);
-
-	struct test_entry *entry = ptr;
-	return entry->check;
-}
-
-static size_t
-test_size(void *ptr, void *data)
-{
-	UT_ASSERTeq(data, TEST_FUNC_DATA);
-
-	struct test_entry *entry = ptr;
-	return entry->size;
-}
-
-static struct test_entry *
-test_entry_new(struct membuf *mbuf, enum membuf_check_result check)
-{
-	struct test_entry *entry =
-		membuf_alloc(mbuf, sizeof(struct test_entry));
-	if (entry == NULL)
-		return NULL;
-	entry->check = check;
-	entry->size = sizeof(struct test_entry);
-
-	return entry;
-}
 
 int
 main(int argc, char *argv[])
 {
-	struct membuf *mbuf = membuf_new(test_check, test_size, TEST_FUNC_DATA,
-		TEST_USER_DATA);
-	UT_ASSERTne(mbuf, NULL);
+	struct membuf *mbuf = membuf_new(TEST_USER_DATA);
 
 	struct test_entry **entries =
 		malloc(sizeof(struct test_entry *) * MAX_TEST_ENTRIES);
@@ -63,7 +27,7 @@ main(int argc, char *argv[])
 	int i;
 	for (i = 0; i < MAX_TEST_ENTRIES; ++i) {
 		struct test_entry *entry =
-			test_entry_new(mbuf, MEMBUF_PTR_IN_USE);
+			membuf_alloc(mbuf, sizeof(struct test_entry));
 		if (entry == NULL)
 			break;
 		UT_ASSERTeq(membuf_ptr_user_data(entry), TEST_USER_DATA);
@@ -78,31 +42,34 @@ main(int argc, char *argv[])
 
 	for (i = 0; i < entries_max / 2; ++i) {
 		struct test_entry *entry = entries[i];
-		entry->check = MEMBUF_PTR_CAN_REUSE;
+		membuf_free(entry);
 	}
 
+	int allocated = 0;
 	for (i = 0; i < MAX_TEST_ENTRIES; ++i) {
 		struct test_entry *entry =
-			test_entry_new(mbuf, MEMBUF_PTR_IN_USE);
+			membuf_alloc(mbuf, sizeof(struct test_entry));
 		if (entry == NULL)
 			break;
 		UT_ASSERTeq(membuf_ptr_user_data(entry), TEST_USER_DATA);
 	}
+	allocated += i;
 	UT_ASSERTeq(i, entries_max / 2);
 
 	for (i = entries_max / 2; i < entries_max; ++i) {
 		struct test_entry *entry = entries[i];
-		entry->check = MEMBUF_PTR_CAN_REUSE;
+		membuf_free(entry);
 	}
 
 	for (i = 0; i < MAX_TEST_ENTRIES; ++i) {
 		struct test_entry *entry =
-			test_entry_new(mbuf, MEMBUF_PTR_IN_USE);
+			membuf_alloc(mbuf, sizeof(struct test_entry));
 		if (entry == NULL)
 			break;
 		UT_ASSERTeq(membuf_ptr_user_data(entry), TEST_USER_DATA);
 	}
-	UT_ASSERTeq(i, entries_max / 2);
+	allocated += i;
+	UT_ASSERTeq(allocated, entries_max);
 
 	membuf_delete(mbuf);
 	free(entries);


### PR DESCRIPTION
Originally I wanted membuf to automatically detect whenever
an allocated memory buffer becomes unused. But the implementation
had a race that might have led to use-after-free in the vdm poll
implementation. The only solution to fix that problem that I came up
with required at least one compare-and-swap even in the happy path,
which might add needless performance overhead.

This patch simplifies membuf reclamation by just adding a free
operation that should be called inside of a vdm delete operation.
This avoids the race at the cost of async movers not being able
to reclaim memory prior to the user calling poll on a completed
future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/50)
<!-- Reviewable:end -->
