### PR TITLE
masync: vdm threads add data function pointers array

### DIFF
--- a/src/include/libminiasync/data_mover_threads.h
+++ b/src/include/libminiasync/data_mover_threads.h
@@ -10,15 +10,17 @@
 extern "C" {
 #endif
 
-struct data_mover_threads;
+typedef void *(*memcpy_fn)(void *dst, const void *src,
+				size_t n, unsigned flags);
 
+struct data_mover_threads;
 struct data_mover_threads *data_mover_threads_new(size_t nthreads,
 	size_t ringbuf_size, enum future_notifier_type desired_notifier);
 struct data_mover_threads *data_mover_threads_default();
-
 struct vdm *data_mover_threads_get_vdm(struct data_mover_threads *dmt);
-
 void data_mover_threads_delete(struct data_mover_threads *dmt);
+void data_mover_threads_set_memcpy_fn(struct data_mover_threads *dmt,
+	memcpy_fn op_memcpy);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add an array of function pointers to change memcpy used by data mover threads. I tried to write it in such way that it won't break the abstraction of vdm, so the data functions can be any function we want, but at the moment there is only memcpy and memcpy with flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/53)
<!-- Reviewable:end -->
