### PR TITLE
common: enable -WX flag on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,7 @@ if(WIN32)
 # It looks like the issue is still unfixed:
 # https://developercommunity.visualstudio.com/t/several-warnings-in-windows-sdk-100177630-in-windo/435362
 	add_flag(-DWIN32_LEAN_AND_MEAN)
-# Enable when all Warnings are fixed.
-	#add_flag(-WX)
+	add_compile_options(/W3 /WX)
 endif()
 
 if(USE_ASAN)

--- a/src/core/membuf.c
+++ b/src/core/membuf.c
@@ -236,7 +236,7 @@ membuf_alloc(struct membuf *membuf, size_t size)
 	tbuf->available -= real_size;
 
 	struct membuf_entry *entry = (struct membuf_entry *)&tbuf->buf[pos];
-	entry->size = real_size;
+	entry->size = (uint32_t)real_size;
 	entry->allocated = 1;
 
 	return &entry->data;

--- a/src/data_mover_threads.c
+++ b/src/data_mover_threads.c
@@ -73,7 +73,7 @@ data_mover_threads_do_operation(struct data_mover_threads_op *op,
 				= &op->op.data.memcpy;
 			memcpy_fn op_memcpy = dmt->op_fns.op_memcpy;
 			op_memcpy(mdata->dest,
-				mdata->src, mdata->n, mdata->flags);
+				mdata->src, mdata->n, (unsigned)mdata->flags);
 		} break;
 		default:
 			ASSERT(0); /* unreachable */
@@ -232,7 +232,7 @@ data_mover_threads_new(size_t nthreads, size_t ringbuf_size,
 	dmt_threads->base = data_mover_threads_vdm;
 	dmt_threads->op_fns = op_fns_default;
 
-	dmt_threads->buf = ringbuf_new(ringbuf_size);
+	dmt_threads->buf = ringbuf_new((unsigned)ringbuf_size);
 	if (dmt_threads->buf == NULL)
 		goto ringbuf_failed;
 


### PR DESCRIPTION
Enables WX and W3 flags on Windows, as well as, fixes the remaining warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/60)
<!-- Reviewable:end -->
