### PR TITLE
masync: make future safe to poll when complete

### DIFF
--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -153,6 +153,8 @@ do {\
 
 #define FUTURE_AS_RUNNABLE(futurep) (&(futurep)->base)
 #define FUTURE_OUTPUT(futurep) (&(futurep)->output)
+#define FUTURE_DATA(futurep) (&(futurep)->data)
+#define FUTURE_STATE(futurep) ((futurep)->base.context.state)
 
 typedef void (*future_map_fn)(struct future_context *lhs,
 			struct future_context *rhs, void *arg);
@@ -185,7 +187,11 @@ do {\
 static inline enum future_state
 future_poll(struct future *fut, struct future_notifier *notifier)
 {
-	return (fut->context.state = fut->task(&fut->context, notifier));
+	if (fut->context.state != FUTURE_STATE_COMPLETE) {
+		fut->context.state = fut->task(&fut->context, notifier);
+	}
+
+	return fut->context.state;
 }
 
 #define FUTURE_BUSY_POLL(_futurep)\

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,8 +22,11 @@ set(SOURCES_DUMMY_TEST
 set(SOURCES_DUMMY_NEGATIVE_TEST
 	dummy_negative/dummy_negative.c)
 
+set(SOURCES_FUTURE_TEST
+	future/test_future.c)
+
 set(SOURCES_MEMCPY_PTHREADS_TEST
-		memcpy_threads/memcpy_threads.c)
+	memcpy_threads/memcpy_threads.c)
 
 set(SOURCES_DATA_MOVER_DML_TEST
 	data_mover_dml/data_mover_dml.c
@@ -58,6 +61,10 @@ add_link_executable(dummy_negative
 		"${SOURCES_DUMMY_NEGATIVE_TEST}"
 		"${LIBS_BASIC}")
 
+add_link_executable(future
+		"${SOURCES_FUTURE_TEST}"
+		"${LIBS_BASIC}")
+
 add_link_executable(memcpy_threads
 		"${SOURCES_MEMCPY_PTHREADS_TEST}"
 		"${LIBS_BASIC}")
@@ -72,6 +79,8 @@ test("dummy_drd" "dummy" test_dummy drd)
 test("dummy_helgrind" "dummy" test_dummy helgrind)
 test("dummy_memcheck" "dummy" test_dummy memcheck)
 test("dummy_negative" "dummy_negative" test_dummy_negative none)
+test("future" "future" test_future none)
+test("future_memcheck" "future" test_future memcheck)
 test("ex_basic" "ex_basic" test_ex_basic none)
 test("ex_basic_async" "ex_basic_async" test_ex_basic_async none)
 test("memcpy_threads" "memcpy_threads" test_memcpy_threads none)

--- a/tests/future/test_future.c
+++ b/tests/future/test_future.c
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "libminiasync/future.h"
+#include "test_helpers.h"
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <libminiasync.h>
+
+#define TEST_MAX_COUNT 10
+#define FAKE_NOTIFIER ((void *)((uintptr_t)(0xDEADBEEF)))
+
+struct foo_data {
+	int counter;
+};
+
+struct foo_output {
+	int result;
+};
+
+FUTURE(foo_fut, struct foo_data, struct foo_output);
+
+enum future_state
+foo_task(struct future_context *context,
+	struct future_notifier *notifier)
+{
+	UT_ASSERTeq(notifier, FAKE_NOTIFIER);
+
+	struct foo_data *data = future_context_get_data(context);
+	data->counter++;
+	if (data->counter == TEST_MAX_COUNT) {
+		struct foo_output *output = future_context_get_output(context);
+		output->result = 1;
+		return FUTURE_STATE_COMPLETE;
+	} else {
+		return FUTURE_STATE_RUNNING;
+	}
+}
+
+struct foo_fut
+async_foo()
+{
+	struct foo_fut fut = {0};
+	FUTURE_INIT(&fut, foo_task);
+	fut.data.counter = 0;
+	fut.output.result = 0;
+
+	return fut;
+}
+
+int
+main(void)
+{
+	struct foo_fut fut = async_foo();
+	UT_ASSERTeq(FUTURE_STATE(&fut), FUTURE_STATE_IDLE);
+
+	struct foo_output *output = FUTURE_OUTPUT(&fut);
+	UT_ASSERTeq(output->result, 0);
+
+	struct foo_data *data = FUTURE_DATA(&fut);
+	UT_ASSERTeq(data->counter, 0);
+
+	enum future_state state = FUTURE_STATE_RUNNING;
+
+	for (int i = 0; i < TEST_MAX_COUNT; ++i) {
+		UT_ASSERTeq(state, FUTURE_STATE_RUNNING);
+		UT_ASSERTeq(FUTURE_STATE(&fut), i == 0 ?
+			FUTURE_STATE_IDLE : FUTURE_STATE_RUNNING);
+		UT_ASSERTeq(data->counter, i);
+		UT_ASSERTeq(output->result, 0);
+
+		state = future_poll(FUTURE_AS_RUNNABLE(&fut), FAKE_NOTIFIER);
+	}
+	UT_ASSERTeq(data->counter, TEST_MAX_COUNT);
+	UT_ASSERTeq(output->result, 1);
+	UT_ASSERTeq(state, FUTURE_STATE_COMPLETE);
+
+	/* polling on a complete future is a noop */
+	state = future_poll(FUTURE_AS_RUNNABLE(&fut), FAKE_NOTIFIER);
+
+	UT_ASSERTeq(data->counter, TEST_MAX_COUNT);
+	UT_ASSERTeq(output->result, 1);
+	UT_ASSERTeq(state, FUTURE_STATE_COMPLETE);
+
+	return 0;
+}

--- a/tests/future/test_future.cmake
+++ b/tests/future/test_future.cmake
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
+# an example for the basic test case
+
+include(${SRC_DIR}/cmake/test_helpers.cmake)
+
+setup()
+
+# The expected input can be provided to the execute function,
+# which will check if the return code of the binary file matches.
+execute(0 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${BUILD}/future)
+
+# execute_assert_pass can be used instead of manually checking if
+# the return code equals zero, however it cannot be used with a tracer.
+# When used with a tracer assert_pass will be skipped.
+execute_assert_pass(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${BUILD}/future)
+
+cleanup()


### PR DESCRIPTION
This patch makes it safe to poll on completed futures,
simplifying group handling of futures (e.g., in runtimes).
I've also added a new basic test and a few tiny helper APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/61)
<!-- Reviewable:end -->
