### PR TITLE
masync: make vdm operation accessible in the future

### DIFF
--- a/doc/data_mover_dml_new.3.md
+++ b/doc/data_mover_dml_new.3.md
@@ -30,7 +30,13 @@ data mover structure
 
 struct data_mover_dml;
 
-struct data_mover_dml *data_mover_dml_new(void);
+enum data_mover_dml_type {
+	DATA_MOVER_DML_SOFTWARE,
+	DATA_MOVER_DML_HARDWARE,
+	DATA_MOVER_DML_AUTO,
+};
+
+struct data_mover_dml *data_mover_dml_new(enum data_mover_dml_type type);
 void data_mover_dml_delete(struct data_mover_dml *dmd);
 ```
 
@@ -39,6 +45,7 @@ For general description of **DML** data mover API, see **miniasync_vdm_dml**(7).
 # DESCRIPTION #
 
 The **data_mover_dml_new**() function allocates and initializes a new **DML** data mover structure.
+The **type** argument maps directly onto the **DML** path types. See the **DML** documentation for more details.
 
 The **data_mover_dml_delete**() function frees and finalizes the **DML** data mover structure
 pointed by *dmd*.

--- a/doc/miniasync_vdm.7.md
+++ b/doc/miniasync_vdm.7.md
@@ -27,10 +27,14 @@ secondary_title: miniasync
 #include <libminiasync.h>
 
 typedef void *(*vdm_operation_new)
-	(struct vdm *vdm, const struct vdm_operation *operation);
-typedef int (*vdm_operation_start)(void *op, struct future_notifier *n);
-typedef enum future_state (*vdm_operation_check)(void *op);
-typedef void (*vdm_operation_delete)(void *op,
+	(struct vdm *vdm, const enum vdm_operation_type type);
+typedef int (*vdm_operation_start)(void *data,
+	const struct vdm_operation *operation,
+	struct future_notifier *n);
+typedef enum future_state (*vdm_operation_check)(void *data,
+	const struct vdm_operation *operation);
+typedef void (*vdm_operation_delete)(void *data,
+	const struct vdm_operation *operation,
 	struct vdm_operation_output *output);
 
 struct vdm {
@@ -57,11 +61,11 @@ compatibility with the **miniasync_future**(7) feature.
 *struct vdm* is a structure required by every virtual data mover operation, for
 example **vdm_memcpy**(3). *struct vdm* has following members:
 
-* *op_new* - allocations and initializations needed by operation
+* *op_new* - allocations needed for the specified operation type
 
 * *op_delete* - deallocations and finalizations of operation
 
-* *op_start* - data mover task that should be executed
+* *op_start* - populates operation data and starts the execution of the task
 
 * *op_check* - data mover task status check
 

--- a/doc/miniasync_vdm_dml.7.md
+++ b/doc/miniasync_vdm_dml.7.md
@@ -42,8 +42,8 @@ by the **miniasync-vdm-dml**(7) library that has dependency on the **DML** libra
 For information about **miniasync_vdm_dml**() library compilation, see *extras/dml/README.md* file.
 
 **DML** data mover supports offloading certain computations to the hardware
-accelerators (e.g. Intel® Data Streaming Accelerator) by using **MINIASYNC_DML_F_PATH_HW**
-flag. To use this feature, make sure that **DML** library is installed with **DML_HW** option.
+accelerators (e.g. Intel® Data Streaming Accelerator). To use this feature, make
+sure that **DML** library is installed with **DML_HW** option.
 For more information about **DML**, see **<https://github.com/intel/DML>**.
 An example of **DML** data mover API usage with flags can be found in **EXAMPLE** section.
 
@@ -56,9 +56,6 @@ To create a new **DML** data mover instance, use **data_mover_dml_new**(3) funct
 **DML** data mover provides the following flags:
 
 * **MINIASYNC_DML_F_MEM_DURABLE** - write to destination is identified as write to durable memory
-
-* **MINIASYNC_DML_F_PATH_HW** - use hardware accelerators (e.g. Intel® Data Streaming Accelerator)
-for operation execution
 
 **DML** data mover supports following operations:
 

--- a/extras/dml/data_mover_dml.c
+++ b/extras/dml/data_mover_dml.c
@@ -13,7 +13,7 @@
 
 struct data_mover_dml {
 	struct vdm base; /* must be first */
-
+	dml_path_t path;
 	struct membuf *membuf;
 };
 
@@ -21,13 +21,11 @@ struct data_mover_dml {
  * data_mover_dml_translate_flags -- translate miniasync-vdm-dml flags
  */
 static void
-data_mover_dml_translate_flags(uint64_t flags, uint64_t *dml_flags,
-	dml_path_t *path)
+data_mover_dml_translate_flags(uint64_t flags, uint64_t *dml_flags)
 {
 	ASSERTeq((flags & ~MINIASYNC_DML_F_VALID_FLAGS), 0);
 
 	*dml_flags = 0;
-	*path = DML_PATH_SW; /* default path */
 	for (uint64_t iflag = 1; flags > 0; iflag = iflag << 1) {
 		if ((flags & iflag) == 0)
 			continue;
@@ -40,10 +38,6 @@ data_mover_dml_translate_flags(uint64_t flags, uint64_t *dml_flags,
 			case MINIASYNC_DML_F_MEM_DURABLE:
 				*dml_flags |= DML_FLAG_DST1_DURABLE;
 				break;
-			/* perform operation using hardware path */
-			case MINIASYNC_DML_F_PATH_HW:
-				*path = DML_PATH_HW;
-				break;
 			default: /* shouldn't be possible */
 				ASSERT(0);
 		}
@@ -54,27 +48,14 @@ data_mover_dml_translate_flags(uint64_t flags, uint64_t *dml_flags,
 }
 
 /*
- * data_mover_dml_memcpy_job_new -- create a new memcpy job struct
+ * data_mover_dml_memcpy_job_init -- initializes new memcpy dml job
  */
 static dml_job_t *
-data_mover_dml_memcpy_job_new(struct data_mover_dml *vdm_dml,
+data_mover_dml_memcpy_job_init(dml_job_t *dml_job,
 	void *dest, void *src, size_t n, uint64_t flags)
 {
-	dml_status_t status;
-	uint32_t job_size;
-	dml_job_t *dml_job = NULL;
-
 	uint64_t dml_flags = 0;
-	dml_path_t path;
-	data_mover_dml_translate_flags(flags, &dml_flags, &path);
-
-	status = dml_get_job_size(path, &job_size);
-	ASSERTeq(status, DML_STATUS_OK);
-
-	dml_job = (dml_job_t *)membuf_alloc(vdm_dml->membuf, job_size);
-
-	status = dml_init_job(path, dml_job);
-	ASSERTeq(status, DML_STATUS_OK);
+	data_mover_dml_translate_flags(flags, &dml_flags);
 
 	dml_job->operation = DML_OP_MEM_MOVE;
 	dml_job->source_first_ptr = (uint8_t *)src;
@@ -113,17 +94,25 @@ data_mover_dml_memcpy_job_submit(dml_job_t *dml_job)
  */
 static void *
 data_mover_dml_operation_new(struct vdm *vdm,
-	const struct vdm_operation *operation)
+	const enum vdm_operation_type type)
 {
 	struct data_mover_dml *vdm_dml = (struct data_mover_dml *)vdm;
+	dml_status_t status;
+	uint32_t job_size;
+	dml_job_t *dml_job;
 
-	switch (operation->type) {
-		case VDM_OPERATION_MEMCPY:
-		return data_mover_dml_memcpy_job_new(vdm_dml,
-			operation->data.memcpy.dest,
-			operation->data.memcpy.src,
-			operation->data.memcpy.n,
-			operation->data.memcpy.flags);
+	switch (type) {
+		case VDM_OPERATION_MEMCPY: {
+			status = dml_get_job_size(vdm_dml->path, &job_size);
+			ASSERTeq(status, DML_STATUS_OK);
+
+			dml_job = membuf_alloc(vdm_dml->membuf, job_size);
+			dml_status_t status =
+				dml_init_job(vdm_dml->path, dml_job);
+			ASSERTeq(status, DML_STATUS_OK);
+
+			return dml_job;
+		}
 		default:
 		ASSERT(0); /* unreachable */
 	}
@@ -134,9 +123,11 @@ data_mover_dml_operation_new(struct vdm *vdm,
  * data_mover_dml_operation_delete -- delete a DML job
  */
 static void
-data_mover_dml_operation_delete(void *op, struct vdm_operation_output *output)
+data_mover_dml_operation_delete(void *data,
+	const struct vdm_operation *operation,
+	struct vdm_operation_output *output)
 {
-	dml_job_t *job = (dml_job_t *)op;
+	dml_job_t *job = (dml_job_t *)data;
 
 	switch (job->operation) {
 		case DML_OP_MEM_MOVE:
@@ -150,16 +141,19 @@ data_mover_dml_operation_delete(void *op, struct vdm_operation_output *output)
 
 	data_mover_dml_memcpy_job_delete(&job);
 
-	membuf_free(op);
+	membuf_free(data);
 }
 
 /*
  * data_mover_dml_operation_check -- checks the status of a DML job
  */
 enum future_state
-data_mover_dml_operation_check(void *op)
+data_mover_dml_operation_check(void *data,
+	const struct vdm_operation *operation)
 {
-	dml_job_t *job = (dml_job_t *)op;
+	SUPPRESS_UNUSED(operation);
+
+	dml_job_t *job = (dml_job_t *)data;
 
 	dml_status_t status = dml_check_job(job);
 	ASSERTne(status, DML_STATUS_JOB_CORRUPTED);
@@ -172,11 +166,17 @@ data_mover_dml_operation_check(void *op)
  * data_mover_dml_operation_start -- start ('submit') asynchronous dml job
  */
 int
-data_mover_dml_operation_start(void *op, struct future_notifier *n)
+data_mover_dml_operation_start(void *data,
+	const struct vdm_operation *operation, struct future_notifier *n)
 {
 	n->notifier_used = FUTURE_NOTIFIER_NONE;
 
-	dml_job_t *job = (dml_job_t *)op;
+	dml_job_t *job = (dml_job_t *)data;
+	data_mover_dml_memcpy_job_init(job,
+		operation->data.memcpy.dest,
+		operation->data.memcpy.src,
+		operation->data.memcpy.n,
+		operation->data.memcpy.flags);
 
 	data_mover_dml_memcpy_job_submit(job);
 
@@ -197,7 +197,7 @@ static struct vdm data_mover_dml_vdm = {
  * data_mover_dml_new -- creates a new dml-based data mover instance
  */
 struct data_mover_dml *
-data_mover_dml_new(void)
+data_mover_dml_new(enum data_mover_dml_type type)
 {
 	struct data_mover_dml *vdm_dml = malloc(sizeof(struct data_mover_dml));
 	if (vdm_dml == NULL)
@@ -205,6 +205,19 @@ data_mover_dml_new(void)
 
 	vdm_dml->membuf = membuf_new(vdm_dml);
 	vdm_dml->base = data_mover_dml_vdm;
+	switch (type) {
+		case DATA_MOVER_DML_HARDWARE:
+			vdm_dml->path = DML_PATH_HW;
+		break;
+		case DATA_MOVER_DML_SOFTWARE:
+			vdm_dml->path = DML_PATH_SW;
+		break;
+		case DATA_MOVER_DML_AUTO:
+			vdm_dml->path = DML_PATH_AUTO;
+		break;
+		default:
+			ASSERT(0);
+	}
 
 	return vdm_dml;
 }

--- a/extras/dml/include/libminiasync-vdm-dml.h
+++ b/extras/dml/include/libminiasync-vdm-dml.h
@@ -19,10 +19,10 @@ extern "C" {
 #endif
 
 /* MINIASYNC_DML flags */
+/* XXX: these flags need to be unified across all vdms */
+
 #define MINIASYNC_DML_F_MEM_DURABLE		(1U << 0)
-#define MINIASYNC_DML_F_PATH_HW			(1U << 1)
-#define MINIASYNC_DML_F_VALID_FLAGS	(MINIASYNC_DML_F_MEM_DURABLE | \
-		MINIASYNC_DML_F_PATH_HW)
+#define MINIASYNC_DML_F_VALID_FLAGS	(MINIASYNC_DML_F_MEM_DURABLE)
 
 #ifdef __cplusplus
 }

--- a/extras/dml/include/libminiasync-vdm-dml/data_mover_dml.h
+++ b/extras/dml/include/libminiasync-vdm-dml/data_mover_dml.h
@@ -13,7 +13,13 @@ extern "C" {
 
 struct data_mover_dml;
 
-struct data_mover_dml *data_mover_dml_new(void);
+enum data_mover_dml_type {
+	DATA_MOVER_DML_SOFTWARE,
+	DATA_MOVER_DML_HARDWARE,
+	DATA_MOVER_DML_AUTO,
+};
+
+struct data_mover_dml *data_mover_dml_new(enum data_mover_dml_type type);
 struct vdm *data_mover_dml_get_vdm(struct data_mover_dml *dmd);
 void data_mover_dml_delete(struct data_mover_dml *dmd);
 

--- a/src/data_mover_sync.c
+++ b/src/data_mover_sync.c
@@ -2,6 +2,7 @@
 /* Copyright 2022, Intel Corporation */
 
 /* disable conditional expression is const warning */
+#include "core/util.h"
 #ifdef _WIN32
 #pragma warning(disable : 4127)
 #endif
@@ -16,8 +17,7 @@ struct data_mover_sync {
 	struct membuf *membuf;
 };
 
-struct data_mover_sync_op {
-	struct vdm_operation op;
+struct data_mover_sync_data {
 	int complete;
 };
 
@@ -26,12 +26,14 @@ struct data_mover_sync_op {
  * are complete immediately after starting.
  */
 static enum future_state
-sync_operation_check(void *op)
+sync_operation_check(void *data, const struct vdm_operation *operation)
 {
-	struct data_mover_sync_op *sync_op = op;
+	SUPPRESS_UNUSED(operation);
+
+	struct data_mover_sync_data *sync_data = data;
 
 	int complete;
-	util_atomic_load_explicit32(&sync_op->complete, &complete,
+	util_atomic_load_explicit32(&sync_data->complete, &complete,
 		memory_order_acquire);
 
 	return complete ? FUTURE_STATE_COMPLETE : FUTURE_STATE_IDLE;
@@ -41,71 +43,75 @@ sync_operation_check(void *op)
  * sync_operation_new -- creates a new sync operation
  */
 static void *
-sync_operation_new(struct vdm *vdm, const struct vdm_operation *operation)
+sync_operation_new(struct vdm *vdm, const enum vdm_operation_type type)
 {
+	SUPPRESS_UNUSED(type);
+
 	struct data_mover_sync *vdm_sync = (struct data_mover_sync *)vdm;
-	struct data_mover_sync_op *sync_op = membuf_alloc(vdm_sync->membuf,
-		sizeof(struct data_mover_sync_op));
-	if (sync_op == NULL)
+	struct data_mover_sync_data *sync_data = membuf_alloc(vdm_sync->membuf,
+		sizeof(struct data_mover_sync_data));
+	if (sync_data == NULL)
 		return NULL;
 
-	sync_op->op = *operation;
-	sync_op->complete = 0;
+	sync_data->complete = 0;
 
-	return sync_op;
+	return sync_data;
 }
 
 /*
  * sync_operation_delete -- deletes sync operation
  */
 static void
-sync_operation_delete(void *op, struct vdm_operation_output *output)
+sync_operation_delete(void *data, const struct vdm_operation *operation,
+	struct vdm_operation_output *output)
 {
-	struct data_mover_sync_op *sync_op = (struct data_mover_sync_op *)op;
-	switch (sync_op->op.type) {
+	switch (operation->type) {
 		case VDM_OPERATION_MEMCPY:
 			output->type = VDM_OPERATION_MEMCPY;
 			output->output.memcpy.dest =
-				sync_op->op.data.memcpy.dest;
+				operation->data.memcpy.dest;
 			break;
 		case VDM_OPERATION_MEMMOVE:
 			output->type = VDM_OPERATION_MEMMOVE;
 			output->output.memmove.dest =
-				sync_op->op.data.memmove.dest;
+				operation->data.memcpy.dest;
 			break;
 		default:
 			ASSERT(0);
 	}
 
-	membuf_free(op);
+	membuf_free(data);
 }
 
 /*
  * sync_operation_start -- start (and perform) a synchronous memory operation
  */
 static int
-sync_operation_start(void *op, struct future_notifier *n)
+sync_operation_start(void *data, const struct vdm_operation *operation,
+	struct future_notifier *n)
 {
-	struct data_mover_sync_op *sync_op = (struct data_mover_sync_op *)op;
+	struct data_mover_sync_data *sync_data =
+		(struct data_mover_sync_data *)data;
+
 	if (n)
 		n->notifier_used = FUTURE_NOTIFIER_NONE;
 
-	switch (sync_op->op.type) {
+	switch (operation->type) {
 		case VDM_OPERATION_MEMCPY:
-			memcpy(sync_op->op.data.memcpy.dest,
-				sync_op->op.data.memcpy.src,
-				sync_op->op.data.memcpy.n);
+			memcpy(operation->data.memcpy.dest,
+				operation->data.memcpy.src,
+				operation->data.memcpy.n);
 			break;
 		case VDM_OPERATION_MEMMOVE:
-			memmove(sync_op->op.data.memmove.dest,
-				sync_op->op.data.memmove.src,
-				sync_op->op.data.memmove.n);
+			memmove(operation->data.memcpy.dest,
+				operation->data.memcpy.src,
+				operation->data.memcpy.n);
 			break;
 		default:
 			ASSERT(0);
 	}
 
-	util_atomic_store_explicit32(&sync_op->complete,
+	util_atomic_store_explicit32(&sync_data->complete,
 		1, memory_order_release);
 
 	return 0;

--- a/src/data_mover_threads.c
+++ b/src/data_mover_threads.c
@@ -21,7 +21,7 @@
 #define DATA_MOVER_THREADS_DEFAULT_RINGBUF_SIZE 128
 
 struct data_mover_threads_op_fns {
-    memcpy_fn op_memcpy;
+	memcpy_fn op_memcpy;
 };
 
 struct data_mover_threads {
@@ -35,12 +35,13 @@ struct data_mover_threads {
 	enum future_notifier_type desired_notifier;
 };
 
-struct data_mover_threads_op {
-	struct vdm_operation op;
+struct data_mover_threads_data {
 	enum future_notifier_type desired_notifier;
 	struct future_notifier notifier;
 	uint64_t complete;
 	uint64_t started;
+
+	struct vdm_operation op;
 };
 
 /*
@@ -64,13 +65,13 @@ void data_mover_threads_set_memcpy_fn(struct data_mover_threads *dmt,
  * operations supported by this data mover
  */
 static void
-data_mover_threads_do_operation(struct data_mover_threads_op *op,
+data_mover_threads_do_operation(struct data_mover_threads_data *data,
 				struct data_mover_threads *dmt)
 {
-	switch (op->op.type) {
+	switch (data->op.type) {
 		case VDM_OPERATION_MEMCPY: {
 			struct vdm_operation_data_memcpy *mdata
-				= &op->op.data.memcpy;
+				= &data->op.data.memcpy;
 			memcpy_fn op_memcpy = dmt->op_fns.op_memcpy;
 			op_memcpy(mdata->dest,
 				mdata->src, mdata->n, (unsigned)mdata->flags);
@@ -80,10 +81,10 @@ data_mover_threads_do_operation(struct data_mover_threads_op *op,
 			break;
 	}
 
-	if (op->desired_notifier == FUTURE_NOTIFIER_WAKER) {
-		FUTURE_WAKER_WAKE(&op->notifier.waker);
+	if (data->desired_notifier == FUTURE_NOTIFIER_WAKER) {
+		FUTURE_WAKER_WAKE(&data->notifier.waker);
 	}
-	util_atomic_store_explicit64(&op->complete, 1, memory_order_release);
+	util_atomic_store_explicit64(&data->complete, 1, memory_order_release);
 }
 
 /*
@@ -95,7 +96,7 @@ data_mover_threads_loop(void *arg)
 {
 	struct data_mover_threads *dmt_threads = arg;
 	struct ringbuf *buf = dmt_threads->buf;
-	struct data_mover_threads_op *op;
+	struct data_mover_threads_data *tdata;
 
 	while (1) {
 		/*
@@ -103,10 +104,10 @@ data_mover_threads_loop(void *arg)
 		 * if he fails, he's waiting until something is added to
 		 * the ringbuffer.
 		 */
-		if ((op = ringbuf_dequeue(buf)) == NULL)
+		if ((tdata = ringbuf_dequeue(buf)) == NULL)
 			return NULL;
 
-		data_mover_threads_do_operation(op, dmt_threads);
+		data_mover_threads_do_operation(tdata, dmt_threads);
 	}
 }
 
@@ -114,18 +115,21 @@ data_mover_threads_loop(void *arg)
  * data_mover_threads_operation_check -- check the status of a thread operation
  */
 static enum future_state
-data_mover_threads_operation_check(void *op)
+data_mover_threads_operation_check(void *data,
+	const struct vdm_operation *operation)
 {
-	struct data_mover_threads_op *opt = op;
+	SUPPRESS_UNUSED(operation);
+
+	struct data_mover_threads_data *tdata = data;
 
 	uint64_t complete;
-	util_atomic_load_explicit64(&opt->complete,
+	util_atomic_load_explicit64(&tdata->complete,
 		&complete, memory_order_acquire);
 	if (complete)
 		return FUTURE_STATE_COMPLETE;
 
 	uint64_t started;
-	util_atomic_load_explicit64(&opt->started,
+	util_atomic_load_explicit64(&tdata->started,
 		&started, memory_order_acquire);
 	if (started)
 		return FUTURE_STATE_RUNNING;
@@ -139,21 +143,22 @@ data_mover_threads_operation_check(void *op)
  */
 static void *
 data_mover_threads_operation_new(struct vdm *vdm,
-	const struct vdm_operation *operation)
+	const enum vdm_operation_type type)
 {
+	SUPPRESS_UNUSED(type);
+
 	struct data_mover_threads *dmt_threads =
 		(struct data_mover_threads *)vdm;
 
-	struct data_mover_threads_op *op =
+	struct data_mover_threads_data *op =
 		membuf_alloc(dmt_threads->membuf,
-		sizeof(struct data_mover_threads_op));
+		sizeof(struct data_mover_threads_data));
 	if (op == NULL)
 		return NULL;
 
 	op->complete = 0;
 	op->started = 0;
 	op->desired_notifier = dmt_threads->desired_notifier;
-	op->op = *operation;
 
 	return op;
 }
@@ -162,46 +167,48 @@ data_mover_threads_operation_new(struct vdm *vdm,
  * vdm_threads_operation_delete -- delete a thread operation
  */
 static void
-data_mover_threads_operation_delete(void *op,
+data_mover_threads_operation_delete(void *data,
+	const struct vdm_operation *operation,
 	struct vdm_operation_output *output)
 {
-	struct data_mover_threads_op *opt = (struct data_mover_threads_op *)op;
-
-	switch (opt->op.type) {
+	switch (operation->type) {
 		case VDM_OPERATION_MEMCPY:
 			output->type = VDM_OPERATION_MEMCPY;
 			output->output.memcpy.dest =
-				opt->op.data.memcpy.dest;
+				operation->data.memcpy.dest;
 			break;
 		default:
 			ASSERT(0);
 	}
 
-	membuf_free(op);
+	membuf_free(data);
 }
 
 /*
  * data_mover_threads_operation_start -- start a memory operation using threads
  */
 static int
-data_mover_threads_operation_start(void *op, struct future_notifier *n)
+data_mover_threads_operation_start(void *data,
+	const struct vdm_operation *operation, struct future_notifier *n)
 {
-	struct data_mover_threads_op *opt = (struct data_mover_threads_op *)op;
+	struct data_mover_threads_data *tdata =
+		(struct data_mover_threads_data *)data;
+	memcpy(&tdata->op, operation, sizeof(*operation));
 
 	if (n) {
-		n->notifier_used = opt->desired_notifier;
-		opt->notifier = *n;
-		if (opt->desired_notifier == FUTURE_NOTIFIER_POLLER) {
-			n->poller.ptr_to_monitor = &opt->complete;
+		n->notifier_used = tdata->desired_notifier;
+		tdata->notifier = *n;
+		if (tdata->desired_notifier == FUTURE_NOTIFIER_POLLER) {
+			n->poller.ptr_to_monitor = &tdata->complete;
 		}
 	} else {
-		opt->desired_notifier = FUTURE_NOTIFIER_NONE;
+		tdata->desired_notifier = FUTURE_NOTIFIER_NONE;
 	}
 
-	struct data_mover_threads *dmt_threads = membuf_ptr_user_data(op);
+	struct data_mover_threads *dmt_threads = membuf_ptr_user_data(tdata);
 
-	if (ringbuf_tryenqueue(dmt_threads->buf, op) == 0) {
-		util_atomic_store_explicit64(&opt->started,
+	if (ringbuf_tryenqueue(dmt_threads->buf, tdata) == 0) {
+		util_atomic_store_explicit64(&tdata->started,
 			FUTURE_STATE_RUNNING, memory_order_release);
 	}
 

--- a/src/include/libminiasync/vdm.h
+++ b/src/include/libminiasync/vdm.h
@@ -49,17 +49,23 @@ struct vdm_operation_data_memmove {
 	uint64_t flags;
 };
 
+/* sized so that sizeof(vdm_operation_data) is 64 */
+#define VDM_OPERATION_DATA_MAX_SIZE (40)
+
 struct vdm_operation {
-	enum vdm_operation_type type;
 	union {
 		struct vdm_operation_data_memcpy memcpy;
 		struct vdm_operation_data_memmove memmove;
+		uint8_t data[VDM_OPERATION_DATA_MAX_SIZE];
 	} data;
+	enum vdm_operation_type type;
+	uint32_t padding;
 };
 
 struct vdm_operation_data {
-	void *op;
+	void *data;
 	struct vdm *vdm;
+	struct vdm_operation operation;
 };
 
 struct vdm_operation_output_memcpy {
@@ -82,10 +88,14 @@ FUTURE(vdm_operation_future,
 	struct vdm_operation_data, struct vdm_operation_output);
 
 typedef void *(*vdm_operation_new)
-	(struct vdm *vdm, const struct vdm_operation *operation);
-typedef int (*vdm_operation_start)(void *op, struct future_notifier *n);
-typedef enum future_state (*vdm_operation_check)(void *op);
-typedef void (*vdm_operation_delete)(void *op,
+	(struct vdm *vdm, const enum vdm_operation_type type);
+typedef int (*vdm_operation_start)(void *data,
+	const struct vdm_operation *operation,
+	struct future_notifier *n);
+typedef enum future_state (*vdm_operation_check)(void *data,
+	const struct vdm_operation *operation);
+typedef void (*vdm_operation_delete)(void *data,
+	const struct vdm_operation *operation,
 	struct vdm_operation_output *output);
 
 struct vdm {
@@ -108,23 +118,23 @@ void vdm_synchronous_delete(struct vdm *vdm);
 static inline enum future_state
 vdm_operation_impl(struct future_context *context, struct future_notifier *n)
 {
-	struct vdm_operation_data *data =
+	struct vdm_operation_data *fdata =
 		(struct vdm_operation_data *)future_context_get_data(context);
-	struct vdm *vdm = data->vdm;
+	struct vdm *vdm = fdata->vdm;
 
 	if (context->state == FUTURE_STATE_IDLE) {
-		if (vdm->op_start(data->op, n) != 0) {
+		if (vdm->op_start(fdata->data, &fdata->operation, n) != 0) {
 			return FUTURE_STATE_IDLE;
 		}
 	}
 
-	enum future_state state = vdm->op_check(data->op);
+	enum future_state state = vdm->op_check(fdata->data, &fdata->operation);
 
 	if (state == FUTURE_STATE_COMPLETE) {
 		struct vdm_operation_output *output =
 			(struct vdm_operation_output *)
 				future_context_get_output(context);
-		vdm->op_delete(data->op, output);
+		vdm->op_delete(fdata->data, &fdata->operation, output);
 		/* variable data is no longer valid! */
 	}
 
@@ -138,15 +148,16 @@ vdm_operation_impl(struct future_context *context, struct future_notifier *n)
 static inline struct vdm_operation_future
 vdm_memcpy(struct vdm *vdm, void *dest, void *src, size_t n, uint64_t flags)
 {
-	struct vdm_operation op;
-	op.type = VDM_OPERATION_MEMCPY;
-	op.data.memcpy.dest = dest;
-	op.data.memcpy.flags = flags;
-	op.data.memcpy.n = n;
-	op.data.memcpy.src = src;
-
-	struct vdm_operation_future future = {0};
-	future.data.op = vdm->op_new(vdm, &op);
+	struct vdm_operation_future future = {.data.operation = {
+		.type = VDM_OPERATION_MEMCPY,
+		.data = {
+			.memcpy.dest = dest,
+			.memcpy.flags = flags,
+			.memcpy.n = n,
+			.memcpy.src = src,
+		}
+	}};
+	future.data.data = vdm->op_new(vdm, VDM_OPERATION_MEMCPY);
 	future.data.vdm = vdm;
 	FUTURE_INIT(&future, vdm_operation_impl);
 
@@ -160,15 +171,17 @@ vdm_memcpy(struct vdm *vdm, void *dest, void *src, size_t n, uint64_t flags)
 static inline struct vdm_operation_future
 vdm_memmove(struct vdm *vdm, void *dest, void *src, size_t n, uint64_t flags)
 {
-	struct vdm_operation op;
-	op.type = VDM_OPERATION_MEMMOVE;
-	op.data.memmove.dest = dest;
-	op.data.memmove.flags = flags;
-	op.data.memmove.n = n;
-	op.data.memmove.src = src;
+	struct vdm_operation_future future = {.data.operation = {
+		.type = VDM_OPERATION_MEMMOVE,
+		.data = {
+			.memcpy.dest = dest,
+			.memcpy.flags = flags,
+			.memcpy.n = n,
+			.memcpy.src = src,
+		}
+	}};
 
-	struct vdm_operation_future future = {0};
-	future.data.op = vdm->op_new(vdm, &op);
+	future.data.data = vdm->op_new(vdm, VDM_OPERATION_MEMMOVE);
 	future.data.vdm = vdm;
 	FUTURE_INIT(&future, vdm_operation_impl);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,9 @@ set(SOURCES_MEMBUF_TEST
 set(SOURCES_MEMMOVE_SYNC_TEST
 	memmove_sync/memmove_sync.c)
 
+set(SOURCES_VDM_TEST
+	vdm/test_vdm.c)
+
 add_custom_target(tests)
 
 add_flag(-Wall)
@@ -80,6 +83,10 @@ add_link_executable(memmove_sync
 		"${SOURCES_MEMMOVE_SYNC_TEST}"
 		"${LIBS_BASIC}")
 
+add_link_executable(vdm
+		"${SOURCES_VDM_TEST}"
+		"${LIBS_BASIC}")
+
 # add test using test function defined in the ctest_helpers.cmake file
 test("dummy" "dummy" test_dummy none)
 test("dummy_drd" "dummy" test_dummy drd)
@@ -91,6 +98,7 @@ test("future_memcheck" "future" test_future memcheck)
 test("memcpy_threads" "memcpy_threads" test_memcpy_threads none)
 test("membuf" "membuf" test_membuf none)
 test("memmove_sync" "memmove_sync" test_memmove_sync none)
+test("vdm" "vdm" test_vdm none)
 
 # add tests running examples only if they are built
 if(BUILD_EXAMPLES)

--- a/tests/data_mover_dml/data_mover_dml.c
+++ b/tests/data_mover_dml/data_mover_dml.c
@@ -8,11 +8,11 @@
 
 #include <libminiasync.h>
 #include <libminiasync-vdm-dml.h>
-
+#include "libminiasync-vdm-dml/data_mover_dml.h"
 #include "util_dml.h"
 
 static int
-dml_memcpy(unsigned flags)
+dml_memcpy(enum data_mover_dml_type type, uint64_t flags)
 {
 	char *buf_a = strdup("testbuf");
 	char *buf_b = strdup("otherbuf");
@@ -20,7 +20,7 @@ dml_memcpy(unsigned flags)
 
 	struct runtime *r = runtime_new();
 
-	struct data_mover_dml *dmd = data_mover_dml_new();
+	struct data_mover_dml *dmd = data_mover_dml_new(type);
 	struct vdm *dml_mover_async = data_mover_dml_get_vdm(dmd);
 
 	struct vdm_operation_future a_to_b = vdm_memcpy(dml_mover_async, buf_b,
@@ -42,19 +42,19 @@ dml_memcpy(unsigned flags)
 static int
 test_dml_basic_memcpy()
 {
-	return dml_memcpy(0);
+	return dml_memcpy(DATA_MOVER_DML_SOFTWARE, 0);
 }
 
 static int
 test_dml_durable_flag_memcpy()
 {
-	return dml_memcpy(MINIASYNC_DML_F_MEM_DURABLE);
+	return dml_memcpy(DATA_MOVER_DML_SOFTWARE, MINIASYNC_DML_F_MEM_DURABLE);
 }
 
 static int
 test_dml_hw_path_flag_memcpy()
 {
-	return dml_memcpy(MINIASYNC_DML_F_PATH_HW);
+	return dml_memcpy(DATA_MOVER_DML_HARDWARE, 0);
 }
 
 int

--- a/tests/vdm/test_vdm.c
+++ b/tests/vdm/test_vdm.c
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+#include "libminiasync/future.h"
+#include "libminiasync/vdm.h"
+#include "test_helpers.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libminiasync.h>
+
+struct alloc_data {
+	size_t n;
+};
+
+struct alloc_output {
+	void *ptr;
+};
+
+FUTURE(alloc_fut, struct alloc_data, struct alloc_output);
+
+enum future_state
+alloc_impl(struct future_context *context, struct future_notifier *notifier)
+{
+	struct alloc_data *data = future_context_get_data(context);
+	struct alloc_output *output = future_context_get_output(context);
+
+	output->ptr = malloc(data->n);
+	UT_ASSERTne(output->ptr, NULL);
+
+	return FUTURE_STATE_COMPLETE;
+}
+
+struct alloc_fut
+async_alloc(size_t size)
+{
+	struct alloc_fut fut = {0};
+	fut.data.n = size;
+	FUTURE_INIT(&fut, alloc_impl);
+	return fut;
+};
+
+struct strdup_data {
+	FUTURE_CHAIN_ENTRY(struct alloc_fut, alloc);
+	FUTURE_CHAIN_ENTRY(struct vdm_operation_future, copy);
+};
+
+struct strdup_output {
+	void *ptr;
+	size_t length;
+};
+
+FUTURE(strdup_fut, struct strdup_data, struct strdup_output);
+
+void
+strdup_map_alloc_to_copy(struct future_context *lhs,
+	struct future_context *rhs, void *arg)
+{
+	struct alloc_output *alloc = future_context_get_output(lhs);
+	struct vdm_operation_data *copy = future_context_get_data(rhs);
+	copy->operation.data.memcpy.dest = alloc->ptr;
+}
+
+void
+strdup_map_copy_to_output(struct future_context *lhs,
+	struct future_context *rhs, void *arg)
+{
+	struct vdm_operation_data *copy = future_context_get_data(lhs);
+	struct strdup_output *strdup = future_context_get_output(rhs);
+	strdup->ptr = copy->operation.data.memcpy.dest;
+	strdup->length = copy->operation.data.memcpy.n;
+}
+
+struct strdup_fut
+async_strdup(struct vdm *vdm, char *s)
+{
+	struct strdup_fut fut = {0};
+
+	size_t len = strlen(s) + 1;
+	FUTURE_CHAIN_ENTRY_INIT(&fut.data.alloc, async_alloc(len),
+		strdup_map_alloc_to_copy, NULL);
+	FUTURE_CHAIN_ENTRY_INIT(&fut.data.copy,
+		vdm_memcpy(vdm, NULL, s, len, 0),
+		strdup_map_copy_to_output, NULL);
+	FUTURE_CHAIN_INIT(&fut);
+
+	return fut;
+}
+
+int
+main(void)
+{
+	UT_ASSERTeq(sizeof(struct vdm_operation_data), 64);
+
+	struct data_mover_sync *sync = data_mover_sync_new();
+	struct vdm *vdm = data_mover_sync_get_vdm(sync);
+
+	static char *hello_world = "Hello World!";
+
+	struct strdup_fut fut = async_strdup(vdm, hello_world);
+	FUTURE_BUSY_POLL(&fut);
+
+	struct strdup_output *output = FUTURE_OUTPUT(&fut);
+	UT_ASSERTeq(strcmp(hello_world, output->ptr), 0);
+	UT_ASSERTeq(strlen(hello_world) + 1, output->length);
+
+	free(output->ptr);
+
+	data_mover_sync_delete(sync);
+
+	return 0;
+}

--- a/tests/vdm/test_vdm.cmake
+++ b/tests/vdm/test_vdm.cmake
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Intel Corporation
+
+# an example for the basic test case
+
+include(${SRC_DIR}/cmake/test_helpers.cmake)
+
+setup()
+
+# The expected input can be provided to the execute function,
+# which will check if the return code of the binary file matches.
+execute(0 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${BUILD}/vdm)
+
+# execute_assert_pass can be used instead of manually checking if
+# the return code equals zero, however it cannot be used with a tracer.
+# When used with a tracer assert_pass will be skipped.
+execute_assert_pass(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${BUILD}/vdm)
+
+cleanup()


### PR DESCRIPTION
Right now the vdm_operation_future hides all operation
details behind a mover-specific data pointer. This
makes it impossible to alter the operation arguments
inside of a chained future. This patch moves all operation
data to the the externally visible vdm_operation_data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/63)
<!-- Reviewable:end -->
