### PR TITLE
 masync: expand chained future functionality 

### DIFF
--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -151,6 +151,15 @@ do {\
 		sizeof((_futurep)->output);\
 } while (0)
 
+#define FUTURE_INIT_COMPLETE(_futurep)\
+do {\
+	(_futurep)->base.task = NULL;\
+	(_futurep)->base.context.state = (FUTURE_STATE_COMPLETE);\
+	(_futurep)->base.context.data_size = sizeof((_futurep)->data);\
+	(_futurep)->base.context.output_size =\
+		sizeof((_futurep)->output);\
+} while (0)
+
 #define FUTURE_AS_RUNNABLE(futurep) (&(futurep)->base)
 #define FUTURE_OUTPUT(futurep) (&(futurep)->output)
 #define FUTURE_DATA(futurep) (&(futurep)->data)
@@ -158,26 +167,80 @@ do {\
 
 typedef void (*future_map_fn)(struct future_context *lhs,
 			struct future_context *rhs, void *arg);
+typedef void (*future_init_fn)(void *future,
+			struct future_context *chain_fut, void *arg);
 
 struct future_chain_entry {
 	future_map_fn map;
-	void *arg;
+	void *map_arg;
+	future_init_fn init;
+	void *init_arg;
+	uint64_t flags;
 	struct future future;
 };
+
+#define FUTURE_CHAIN_FLAG_ENTRY_LAST		(((uint64_t)1) << 0)
+#define FUTURE_CHAIN_FLAG_ENTRY_PROCESSED	(((uint64_t)1) << 1)
+#define FUTURE_CHAIN_VALID_FLAGS (FUTURE_CHAIN_FLAG_ENTRY_LAST |\
+	FUTURE_CHAIN_FLAG_ENTRY_PROCESSED)
+
+enum future_chain_entry_type {
+	FUTURE_CHAIN_ENTRY_REGULAR = 1,
+	FUTURE_CHAIN_ENTRY_LAST = 2,
+};
+
+typedef uint8_t _future_entry_type_regular[FUTURE_CHAIN_ENTRY_REGULAR];
+typedef uint8_t _future_entry_type_last[FUTURE_CHAIN_ENTRY_LAST];
 
 #define FUTURE_CHAIN_ENTRY(_future_type, _name)\
 struct {\
 	future_map_fn map;\
-	void *arg;\
+	void *map_arg;\
+	future_init_fn init;\
+	void *init_arg;\
+	_future_entry_type_regular *flags;\
+	_future_type fut;\
+} _name
+
+#define FUTURE_CHAIN_ENTRY_LAST(_future_type, _name)\
+struct {\
+	future_map_fn map;\
+	void *map_arg;\
+	future_init_fn init;\
+	void *init_arg;\
+	_future_entry_type_last *flags;\
 	_future_type fut;\
 } _name
 
 #define FUTURE_CHAIN_ENTRY_INIT(_entry, _fut, _map, _map_arg)\
 do {\
 	(_entry)->fut = (_fut);\
-	(_entry)->map = _map;\
-	(_entry)->arg = _map_arg;\
+	(_entry)->map = (_map);\
+	(_entry)->map_arg = (_map_arg);\
+	(_entry)->init = NULL;\
+	(_entry)->init_arg = NULL;\
+	(_entry)->flags = (void *)(sizeof(*(_entry)->flags) ==\
+		FUTURE_CHAIN_ENTRY_LAST ? FUTURE_CHAIN_FLAG_ENTRY_LAST : 0);\
 } while (0)
+
+#define FUTURE_CHAIN_ENTRY_LAZY_INIT(_entry, _init, _init_arg, _map, _map_arg)\
+do {\
+	(_entry)->map = (_map);\
+	(_entry)->map_arg = (_map_arg);\
+	(_entry)->init = (_init);\
+	(_entry)->init_arg = (_init_arg);\
+	(_entry)->flags = (void *)(sizeof(*(_entry)->flags) ==\
+		FUTURE_CHAIN_ENTRY_LAST ? FUTURE_CHAIN_FLAG_ENTRY_LAST : 0);\
+} while (0)
+
+#define FUTURE_CHAIN_ENTRY_HAS_FLAG(_entry, _flag)\
+(((_entry)->flags & (_flag)) == (_flag))
+
+#define FUTURE_CHAIN_ENTRY_IS_LAST(_entry)\
+FUTURE_CHAIN_ENTRY_HAS_FLAG(_entry, FUTURE_CHAIN_FLAG_ENTRY_LAST)
+
+#define FUTURE_CHAIN_ENTRY_IS_PROCESSED(_entry)\
+FUTURE_CHAIN_ENTRY_HAS_FLAG(_entry, FUTURE_CHAIN_FLAG_ENTRY_PROCESSED)
 
 /*
  * TODO: Notifiers have to be copied into the state of the future, so we might
@@ -216,6 +279,10 @@ async_chain_impl(struct future_context *ctx, struct future_notifier *notifier)
 	 * Futures must be laid out sequentially in memory for this to work.
 	 */
 	while (entry != NULL) {
+		if (entry->init) {
+			entry->init(&entry->future, ctx, entry->init_arg);
+			entry->init = NULL;
+		}
 		/*
 		 * `struct future` starts with a pointer, so the structure will
 		 * be pointer-size aligned. We need to account for that when
@@ -224,17 +291,28 @@ async_chain_impl(struct future_context *ctx, struct future_notifier *notifier)
 		used_data += _MINIASYNC_ALIGN_UP(
 			sizeof(struct future_chain_entry) +
 			future_context_get_size(&entry->future.context));
-		struct future_chain_entry *next = used_data != ctx->data_size
-			? (struct future_chain_entry *)(data + used_data)
-			: NULL;
-		if (entry->future.context.state != FUTURE_STATE_COMPLETE) {
+		struct future_chain_entry *next = NULL;
+		if (!FUTURE_CHAIN_ENTRY_IS_LAST(entry) &&
+		    used_data != ctx->data_size) {
+			next = (struct future_chain_entry *)(data + used_data);
+		}
+		if (!FUTURE_CHAIN_ENTRY_IS_PROCESSED(entry)) {
 			if (future_poll(&entry->future, notifier) ==
-			    FUTURE_STATE_COMPLETE && entry->map) {
-				entry->map(&entry->future.context,
+			    FUTURE_STATE_COMPLETE) {
+				if (entry->map) {
+					if (next && next->init) {
+						next->init(&next->future, ctx,
+							next->init_arg);
+						next->init = NULL;
+					}
+					entry->map(&entry->future.context,
 							next ?
 							&next->future.context
 							: ctx,
-							entry->arg);
+							entry->map_arg);
+				}
+				entry->flags |=
+					FUTURE_CHAIN_FLAG_ENTRY_PROCESSED;
 			} else {
 				return FUTURE_STATE_RUNNING;
 			}

--- a/tests/future/test_future.c
+++ b/tests/future/test_future.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <libminiasync.h>
 
 #define TEST_MAX_COUNT 10
@@ -195,11 +196,115 @@ test_chained_future()
 	UT_ASSERTeq(output->result_sum, 2);
 }
 
+struct multiply_data {
+	int a;
+	int b;
+};
+
+struct multiply_output {
+	int result;
+};
+
+FUTURE(multiply_fut, struct multiply_data, struct multiply_output);
+
+struct multiply_fut
+async_multiply(int a, int b)
+{
+	struct multiply_fut fut = {0};
+	FUTURE_INIT_COMPLETE(&fut);
+	fut.data.a = a;
+	fut.data.b = b;
+	fut.output.result = a * b;
+
+	return fut;
+}
+
+void
+test_completed_future()
+{
+	struct multiply_fut fut = async_multiply(2, 3);
+	UT_ASSERTeq(FUTURE_STATE(&fut), FUTURE_STATE_COMPLETE);
+	FUTURE_BUSY_POLL(&fut);
+	UT_ASSERTeq(FUTURE_STATE(&fut), FUTURE_STATE_COMPLETE);
+}
+
+struct multiply_up_down_data {
+	FUTURE_CHAIN_ENTRY(struct multiply_fut, mul);
+	FUTURE_CHAIN_ENTRY_LAST(struct up_down_fut, up_down);
+	int num;
+	int count;
+};
+
+struct multiply_up_down_output {
+	int result_sum;
+};
+
+FUTURE(multiply_up_down_fut,
+	struct multiply_up_down_data, struct multiply_up_down_output);
+
+void
+multiply_init(void *future, struct future_context *chain_fut, void *arg)
+{
+	struct multiply_up_down_data *data = future_context_get_data(chain_fut);
+	struct multiply_fut fut = async_multiply(data->count, data->num);
+	memcpy(future, &fut, sizeof(fut));
+}
+
+void
+up_down_init(void *future, struct future_context *chain_fut, void *arg)
+{
+	struct multiply_up_down_data *data = future_context_get_data(chain_fut);
+	struct up_down_fut fut = async_up_down(data->mul.fut.output.result);
+	memcpy(future, &fut, sizeof(fut));
+}
+
+void
+up_down_to_output(struct future_context *lhs,
+	struct future_context *rhs, void *arg)
+{
+	struct up_down_output *ud_output =
+		future_context_get_output(lhs);
+	struct multiply_up_down_output *mud_output =
+		future_context_get_output(rhs);
+	mud_output->result_sum = ud_output->result_sum;
+}
+
+struct multiply_up_down_fut
+async_multiply_up_down(int count, int num)
+{
+	struct multiply_up_down_fut fut = {0};
+	fut.data.count = count;
+	fut.data.num = num;
+	FUTURE_CHAIN_ENTRY_LAZY_INIT(&fut.data.mul,
+		multiply_init, NULL,
+		NULL, NULL);
+	FUTURE_CHAIN_ENTRY_LAZY_INIT(&fut.data.up_down,
+		up_down_init, NULL,
+		up_down_to_output, NULL);
+	FUTURE_CHAIN_INIT(&fut);
+
+	return fut;
+}
+
+void
+test_lazy_init()
+{
+	struct multiply_up_down_fut fut = async_multiply_up_down(5, 5);
+	while (future_poll(FUTURE_AS_RUNNABLE(&fut), FAKE_NOTIFIER) !=
+		FUTURE_STATE_COMPLETE) { _mm_pause(); }
+	struct multiply_up_down_output *mud_output = FUTURE_OUTPUT(&fut);
+	UT_ASSERTeq(mud_output->result_sum, 2);
+	struct multiply_up_down_data *mud_data = FUTURE_DATA(&fut);
+	UT_ASSERTeq(mud_data->up_down.fut.data.up.fut.data.counter, 5 * 5);
+}
+
 int
 main(void)
 {
 	test_single_future();
 	test_chained_future();
+	test_completed_future();
+	test_lazy_init();
 
 	return 0;
 }

--- a/tests/vdm/test_vdm.c
+++ b/tests/vdm/test_vdm.c
@@ -42,7 +42,9 @@ async_alloc(size_t size)
 
 struct strdup_data {
 	FUTURE_CHAIN_ENTRY(struct alloc_fut, alloc);
-	FUTURE_CHAIN_ENTRY(struct vdm_operation_future, copy);
+	FUTURE_CHAIN_ENTRY_LAST(struct vdm_operation_future, copy);
+	void *src;
+	size_t length;
 };
 
 struct strdup_output {
@@ -87,6 +89,50 @@ async_strdup(struct vdm *vdm, char *s)
 	return fut;
 }
 
+void
+strdup_init(void *future, struct future_context *chain_fut, void *arg)
+{
+	struct vdm *vdm = arg;
+	struct strdup_data *strdup_data =
+		future_context_get_data(chain_fut);
+
+	struct vdm_operation_future fut = vdm_memcpy(vdm,
+		strdup_data->alloc.fut.output.ptr,
+		strdup_data->src, strdup_data->length, 0);
+	memcpy(future, &fut, sizeof(fut));
+}
+
+struct strdup_fut
+async_lazy_strdup(struct vdm *vdm, char *s)
+{
+	struct strdup_fut fut = {0};
+	fut.data.src = s;
+	fut.data.length = strlen(s) + 1;
+
+	FUTURE_CHAIN_ENTRY_INIT(&fut.data.alloc, async_alloc(fut.data.length),
+		strdup_map_alloc_to_copy, NULL);
+	FUTURE_CHAIN_ENTRY_LAZY_INIT(&fut.data.copy,
+		strdup_init, vdm,
+		strdup_map_copy_to_output, NULL);
+	FUTURE_CHAIN_INIT(&fut);
+
+	return fut;
+}
+
+static char *hello_world = "Hello World!";
+
+void
+test_strdup_fut(struct strdup_fut fut)
+{
+	FUTURE_BUSY_POLL(&fut);
+
+	struct strdup_output *output = FUTURE_OUTPUT(&fut);
+	UT_ASSERTeq(strcmp(hello_world, output->ptr), 0);
+	UT_ASSERTeq(strlen(hello_world) + 1, output->length);
+
+	free(output->ptr);
+}
+
 int
 main(void)
 {
@@ -95,16 +141,8 @@ main(void)
 	struct data_mover_sync *sync = data_mover_sync_new();
 	struct vdm *vdm = data_mover_sync_get_vdm(sync);
 
-	static char *hello_world = "Hello World!";
-
-	struct strdup_fut fut = async_strdup(vdm, hello_world);
-	FUTURE_BUSY_POLL(&fut);
-
-	struct strdup_output *output = FUTURE_OUTPUT(&fut);
-	UT_ASSERTeq(strcmp(hello_world, output->ptr), 0);
-	UT_ASSERTeq(strlen(hello_world) + 1, output->length);
-
-	free(output->ptr);
+	test_strdup_fut(async_strdup(vdm, hello_world));
+	test_strdup_fut(async_lazy_strdup(vdm, hello_world));
 
 	data_mover_sync_delete(sync);
 


### PR DESCRIPTION
This patch adds the ability for chained entries to be
lazily initialized and introduces a new FUTURE_CHAIN_ENTRY_LAST
macro that makes it possible for chained future data structs
to contain an extra state after the last chain entry.

Based on #63

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/64)
<!-- Reviewable:end -->
