### PR TITLE
masync: fix C++ compiler's warnings

### DIFF
--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -205,7 +205,7 @@ async_chain_impl(struct future_context *ctx, struct future_notifier *notifier)
 #define _MINIASYNC_ALIGN_UP(size)\
 	(((size) + _MINIASYNC_PTRSIZE - 1) & ~(_MINIASYNC_PTRSIZE - 1))
 
-	uint8_t *data = future_context_get_data(ctx);
+	uint8_t *data = (uint8_t *)future_context_get_data(ctx);
 
 	struct future_chain_entry *entry = (struct future_chain_entry *)(data);
 	size_t used_data = 0;

--- a/src/include/libminiasync/vdm.h
+++ b/src/include/libminiasync/vdm.h
@@ -94,7 +94,8 @@ void vdm_synchronous_delete(struct vdm *vdm);
 static inline enum future_state
 vdm_operation_impl(struct future_context *context, struct future_notifier *n)
 {
-	struct vdm_operation_data *data = future_context_get_data(context);
+	struct vdm_operation_data *data =
+		(struct vdm_operation_data *)future_context_get_data(context);
 	struct vdm *vdm = data->vdm;
 
 	if (context->state == FUTURE_STATE_IDLE) {
@@ -107,7 +108,8 @@ vdm_operation_impl(struct future_context *context, struct future_notifier *n)
 
 	if (state == FUTURE_STATE_COMPLETE) {
 		struct vdm_operation_output *output =
-			future_context_get_output(context);
+			(struct vdm_operation_output *)
+				future_context_get_output(context);
 		vdm->op_delete(data->op, output);
 		/* variable data is no longer valid! */
 	}


### PR DESCRIPTION
"invalid conversion from ‘void*’ to ...".

Each time future.h or vdm.h were included in a C++ build
(pmemstream's in my case) it was causing errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/69)
<!-- Reviewable:end -->
