### PR TITLE
Allow builds on other architectures

### DIFF
--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -17,6 +17,9 @@
 
 #include "cpu.h"
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
+	defined(_M_AMD64)
+
 #define EAX_IDX 0
 #define EBX_IDX 1
 #define ECX_IDX 2
@@ -42,10 +45,6 @@ cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 {
 	__cpuidex((int *)cpuinfo, (int)func, (int)subfunc);
 }
-
-#else
-
-#error unsupported compiler
 
 #endif
 
@@ -78,3 +77,12 @@ is_cpu_movdir64b_present(void)
 {
 	return is_cpu_feature_present(0x7, ECX_IDX, bit_MOVDIR64B);
 }
+
+#else
+
+/*
+ * Nothing to be done here yet. There is no support for 64B atomic copy on
+ * the other architectures yet.
+ */
+
+#endif

--- a/src/core/cpu.h
+++ b/src/core/cpu.h
@@ -8,6 +8,11 @@
  * cpu.h -- definitions for "cpu" module
  */
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
+	defined(_M_AMD64)
+
 int is_cpu_movdir64b_present(void);
+
+#endif
 
 #endif

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -577,6 +577,23 @@ static
 #define SUPPRESS_ARG_8(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_7(__VA_ARGS__)
 #define SUPPRESS_ARG_9(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_8(__VA_ARGS__)
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
+	defined(_M_AMD64)
+
+#include <emmintrin.h>
+#define WAIT() _mm_pause()
+
+#else
+
+/*
+ * Notice there are better implementations for wait-like functions on other
+ * architectures (e.g. powerpc64le), but the current code is generic enough
+ * and doesn't break the build.
+ */
+#define WAIT() do {} while (0)
+
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/core/util.h
+++ b/src/core/util.h
@@ -578,7 +578,7 @@ static
 #define SUPPRESS_ARG_9(X, ...) SUPPRESS_ARG_1(X); SUPPRESS_ARG_8(__VA_ARGS__)
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
-	defined(_M_AMD64)
+	defined(_M_AMD64) || !defined(_MSC_VER)
 
 #include <emmintrin.h>
 #define WAIT() _mm_pause()

--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -63,7 +63,16 @@
 
 #include <stddef.h>
 #include <stdint.h>
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64) || \
+	defined(_M_AMD64)
 #include <emmintrin.h>
+
+#define __FUTURE_WAIT() _mm_pause()
+#else
+#include <sched.h>
+#define __FUTURE_WAIT() sched_yield()
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -261,7 +270,7 @@ future_poll(struct future *fut, struct future_notifier *notifier)
 
 #define FUTURE_BUSY_POLL(_futurep)\
 while (future_poll(FUTURE_AS_RUNNABLE((_futurep)), NULL) !=\
-	FUTURE_STATE_COMPLETE) { _mm_pause(); }
+	FUTURE_STATE_COMPLETE) { __FUTURE_WAIT(); }
 
 static inline enum future_state
 async_chain_impl(struct future_context *ctx, struct future_notifier *notifier)

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2021-2022, Intel Corporation */
 
+#include <stdlib.h>
+
 #include "libminiasync/runtime.h"
 #include "core/os_thread.h"
 #include "core/os.h"

--- a/src/runtime.c
+++ b/src/runtime.c
@@ -6,7 +6,7 @@
 #include "libminiasync/runtime.h"
 #include "core/os_thread.h"
 #include "core/os.h"
-#include <emmintrin.h>
+#include "core/util.h"
 
 struct runtime_waker_data {
 	os_cond_t *cond;
@@ -107,7 +107,7 @@ runtime_wait_multiple(struct runtime *runtime, struct future *futs[],
 			if (ndone == nfuts)
 				return;
 
-			_mm_pause();
+			WAIT();
 		}
 		runtime_sleep(runtime);
 	}

--- a/tests/future/test_future.c
+++ b/tests/future/test_future.c
@@ -3,6 +3,7 @@
 
 #include "libminiasync/future.h"
 #include "test_helpers.h"
+#include "core/util.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -290,7 +291,7 @@ test_lazy_init()
 {
 	struct multiply_up_down_fut fut = async_multiply_up_down(5, 5);
 	while (future_poll(FUTURE_AS_RUNNABLE(&fut), FAKE_NOTIFIER) !=
-		FUTURE_STATE_COMPLETE) { _mm_pause(); }
+		FUTURE_STATE_COMPLETE) { WAIT(); }
 	struct multiply_up_down_output *mud_output = FUTURE_OUTPUT(&fut);
 	UT_ASSERTeq(mud_output->result_sum, 2);
 	struct multiply_up_down_data *mud_data = FUTURE_DATA(&fut);


### PR DESCRIPTION
This PR has 2 commits:

1. Fix a warning from GCC.
2. Make the code more architecture-agnostic in order to build for other architectures.

After they, I'm able to successfully build and test miniasync on ppc64le when using `-DCOMPILE_DML=OFF`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/80)
<!-- Reviewable:end -->
