### PR TITLE
a stray semicolon warning

### DIFF
--- a/tests/vdm/test_vdm.c
+++ b/tests/vdm/test_vdm.c
@@ -36,7 +36,7 @@ async_alloc(size_t size)
 	fut.data.n = size;
 	FUTURE_INIT(&fut, alloc_impl);
 	return fut;
-};
+}
 
 struct strdup_data {
 	FUTURE_CHAIN_ENTRY(struct alloc_fut, alloc);


### PR DESCRIPTION
tests/vdm/test_vdm.c:39:2: warning: ISO C does not allow extra ‘;’ outside of a function

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/93)
<!-- Reviewable:end -->
