### PR TITLE
common: replace improper 'RPMA' in man pages with 'MINIASYNC'

### DIFF
--- a/utils/check-commit.sh
+++ b/utils/check-commit.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2021, Intel Corporation
+# Copyright 2016-2022, Intel Corporation
 
 #
-# Used to check whether all the commit messages in a pull request
-# follow the GIT/RPMA guidelines.
+# Used to check whether all commit messages in a pull request
+# follow the GIT and/or project's guidelines.
 #
 # usage: ./check-commit.sh commit
 #

--- a/utils/check-commits.sh
+++ b/utils/check-commits.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2022, Intel Corporation
 
 #
-# Used to check whether all the commit messages in a pull request
-# follow the GIT/RPMA guidelines.
+# Used to check whether all commit messages in a pull request
+# follow the GIT and/or project's guidelines.
 #
 # usage: ./check-commits.sh [range]
 #

--- a/utils/md2man/default.man
+++ b/utils/md2man/default.man
@@ -8,7 +8,7 @@ $endif$
 $if(adjusting)$
 .ad $adjusting$
 $endif$
-.TH "$title$" "$section$" "$date$" "RPMA - $secondary_title$ version $version$" "RPMA Programmer's Manual"
+.TH "$title$" "$section$" "$date$" "MINIASYNC - $secondary_title$ version $version$" "MINIASYNC Programmer's Manual"
 $if(hyphenate)$
 .hy
 $else$

--- a/utils/src2mans.sh
+++ b/utils/src2mans.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 
 #
 # src2mans -- extract man pages from source files
@@ -61,7 +61,7 @@ do
 	MANUALS="$(mktemp)"
 	ERRORS="$(mktemp)"
 
-	src2man -r RPMA -v "RPMA Programmer's Manual" $MAN > $MANUALS 2> $ERRORS
+	src2man -r MINIASYNC -v "MINIASYNC Programmer's Manual" $MAN > $MANUALS 2> $ERRORS
 	# gawk 5.0.1 does not recognize expressions \;|\,|\o  as regex operator
 	sed -i -r "/warning: regexp escape sequence \`[\][;,o]' is not a known regexp operator/d" $ERRORS
 	# remove empty lines


### PR DESCRIPTION
along with other 'RPMA' occurences in (most likely copy-pasted) scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/99)
<!-- Reviewable:end -->
