### PR TITLE
Avoid casting error on C++ compilation

### DIFF
--- a/src/include/libminiasync/future.h
+++ b/src/include/libminiasync/future.h
@@ -385,7 +385,7 @@ future_has_property_default(void *future, enum future_property property)
 static inline int
 future_chain_has_property(void *future, enum future_property property)
 {
-	struct future *fut = future;
+	struct future *fut = (struct future *)future;
 	struct future_context *ctx = &fut->context;
 	uint8_t *data = (uint8_t *)future_context_get_data(ctx);
 	struct future_chain_entry *entry = (struct future_chain_entry *)(data);


### PR DESCRIPTION
This change introduces explicit casting to avoid following error:
invalid conversion from 'void*' to 'future*'.
The newest version of miniasync blocks pmemstream build.
Best regards,
Krzysztof Filipek

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/miniasync/109)
<!-- Reviewable:end -->
